### PR TITLE
feat: integrate plugin capabilities from sigild

### DIFF
--- a/src/sigil_ml/config.py
+++ b/src/sigil_ml/config.py
@@ -24,3 +24,8 @@ def models_dir() -> Path:
 def weights_path(model_name: str) -> Path:
     """Return the path to a specific model's weight file."""
     return models_dir() / f"{model_name}.joblib"
+
+
+def sigild_plugin_url() -> str:
+    """Return the URL for the sigild plugin ingest/capabilities API."""
+    return os.environ.get("SIGILD_PLUGIN_URL", "http://127.0.0.1:7775")

--- a/src/sigil_ml/models/activity.py
+++ b/src/sigil_ml/models/activity.py
@@ -153,13 +153,52 @@ class ActivityClassifier:
         if kind == "process":
             return {"category": "navigating", "confidence": 0.6, "method": "rules"}
 
-        # Plugin-sourced events.
+        # Plugin-sourced events — use source and kind to classify.
         source = event.get("source", "")
-        if source in ("github", "jira", "slack"):
+        event_kind = event.get("kind", "")
+
+        # Known plugin sources with category mappings.
+        if source in ("github", "gitlab", "bitbucket"):
+            if event_kind in ("pr_status", "pr_review", "pr_comment"):
+                return {"category": "communicating", "confidence": 0.8, "method": "rules"}
+            if event_kind in ("ci_status", "check_run"):
+                return {"category": "verifying", "confidence": 0.8, "method": "rules"}
+            return {"category": "integrating", "confidence": 0.7, "method": "rules"}
+
+        if source in ("jira", "linear", "shortcut", "asana"):
             return {"category": "communicating", "confidence": 0.7, "method": "rules"}
+
+        if source in ("slack", "teams", "discord"):
+            return {"category": "communicating", "confidence": 0.8, "method": "rules"}
+
+        if source in ("sentry", "datadog", "pagerduty", "grafana"):
+            return {"category": "researching", "confidence": 0.7, "method": "rules"}
+
+        if source in ("vscode", "jetbrains", "neovim", "cursor"):
+            return {"category": "editing", "confidence": 0.7, "method": "rules"}
+
+        # Try dynamic plugin lookup for unknown sources.
+        if source:
+            category = self._classify_plugin_event(source, event_kind)
+            if category:
+                return {"category": category, "confidence": 0.6, "method": "rules"}
 
         # Unknown → idle.
         return {"category": "idle", "confidence": 0.5, "method": "rules"}
+
+    @staticmethod
+    def _classify_plugin_event(source: str, event_kind: str) -> str | None:
+        """Try to classify a plugin event using capabilities discovery."""
+        try:
+            from sigil_ml.plugins import get_event_kinds_for_plugin
+            data_sources = get_event_kinds_for_plugin(source)
+            if not data_sources:
+                return None
+            # If the plugin reports data sources, it's likely communicating
+            # or integrating — default to communicating for unknown plugins.
+            return "communicating"
+        except Exception:
+            return None
 
     def _classify_ml(self, event: dict) -> dict:
         """ML-based classification using trained SGDClassifier."""

--- a/src/sigil_ml/plugins.py
+++ b/src/sigil_ml/plugins.py
@@ -1,0 +1,96 @@
+"""Plugin capabilities discovery — queries sigild for installed plugins and their actions."""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+import urllib.request
+import urllib.error
+
+from sigil_ml import config
+
+logger = logging.getLogger(__name__)
+
+# Cache capabilities for 5 minutes to avoid hammering sigild.
+_CACHE_TTL_SEC = 300
+_cache: dict | None = None
+_cache_ts: float = 0.0
+
+
+def fetch_capabilities() -> dict:
+    """Fetch plugin capabilities from sigild's HTTP API.
+
+    Returns a dict with:
+        plugins: list of dicts, each with:
+            plugin: str (name)
+            actions: list of {name, description, command}
+            data_sources: list of str
+
+    Caches the result for 5 minutes. Returns empty on failure (non-fatal).
+    """
+    global _cache, _cache_ts
+
+    now = time.time()
+    if _cache is not None and (now - _cache_ts) < _CACHE_TTL_SEC:
+        return _cache
+
+    url = f"{config.sigild_plugin_url()}/api/v1/capabilities"
+    try:
+        req = urllib.request.Request(url, method="GET")
+        with urllib.request.urlopen(req, timeout=3) as resp:
+            data = json.loads(resp.read())
+            _cache = data
+            _cache_ts = now
+            logger.debug("plugins: fetched %d plugin capabilities", len(data.get("plugins", [])))
+            return data
+    except (urllib.error.URLError, OSError, json.JSONDecodeError, TimeoutError) as e:
+        logger.debug("plugins: capabilities fetch failed (sigild may not be running): %s", e)
+        return {"plugins": []}
+
+
+def get_plugin_names() -> list[str]:
+    """Return names of all installed plugins."""
+    data = fetch_capabilities()
+    return [p.get("plugin", "") for p in data.get("plugins", [])]
+
+
+def get_data_sources() -> list[str]:
+    """Return all data sources across installed plugins."""
+    data = fetch_capabilities()
+    sources: list[str] = []
+    for p in data.get("plugins", []):
+        sources.extend(p.get("data_sources", []))
+    return sources
+
+
+def get_actions() -> list[dict]:
+    """Return all actions across installed plugins."""
+    data = fetch_capabilities()
+    actions: list[dict] = []
+    for p in data.get("plugins", []):
+        plugin_name = p.get("plugin", "")
+        for action in p.get("actions", []):
+            actions.append({
+                "plugin": plugin_name,
+                "name": action.get("name", ""),
+                "description": action.get("description", ""),
+                "command": action.get("command", ""),
+            })
+    return actions
+
+
+def get_event_kinds_for_plugin(plugin_name: str) -> list[str]:
+    """Return data source event kinds for a specific plugin."""
+    data = fetch_capabilities()
+    for p in data.get("plugins", []):
+        if p.get("plugin") == plugin_name:
+            return p.get("data_sources", [])
+    return []
+
+
+def invalidate_cache() -> None:
+    """Force re-fetch on next call."""
+    global _cache, _cache_ts
+    _cache = None
+    _cache_ts = 0.0

--- a/src/sigil_ml/server.py
+++ b/src/sigil_ml/server.py
@@ -319,6 +319,13 @@ async def predict_quality(req: QualityRequest) -> QualityResponse:
     )
 
 
+@app.get("/plugins")
+async def plugins() -> dict:
+    """Return installed plugin capabilities from sigild."""
+    from sigil_ml.plugins import fetch_capabilities
+    return fetch_capabilities()
+
+
 def _run_training(db_path: str) -> None:
     """Run training in a background thread."""
     global _training_in_progress

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -164,10 +164,29 @@ class TestActivityClassifier:
         result = clf.classify({"kind": "unknown"})
         assert result["category"] == "idle"
 
-    def test_plugin_source_classifies_as_communicating(self) -> None:
+    def test_plugin_source_github_classifies_as_integrating(self) -> None:
         from sigil_ml.models.activity import ActivityClassifier
         clf = ActivityClassifier()
+        # GitHub events without specific kind default to integrating.
         result = clf.classify({"kind": "plugin", "source": "github", "payload": {}})
+        assert result["category"] == "integrating"
+
+    def test_plugin_source_github_pr_classifies_as_communicating(self) -> None:
+        from sigil_ml.models.activity import ActivityClassifier
+        clf = ActivityClassifier()
+        result = clf.classify({"kind": "pr_review", "source": "github", "payload": {}})
+        assert result["category"] == "communicating"
+
+    def test_plugin_source_jira_classifies_as_communicating(self) -> None:
+        from sigil_ml.models.activity import ActivityClassifier
+        clf = ActivityClassifier()
+        result = clf.classify({"kind": "story_update", "source": "jira", "payload": {}})
+        assert result["category"] == "communicating"
+
+    def test_plugin_source_slack_classifies_as_communicating(self) -> None:
+        from sigil_ml.models.activity import ActivityClassifier
+        clf = ActivityClassifier()
+        result = clf.classify({"kind": "message", "source": "slack", "payload": {}})
         assert result["category"] == "communicating"
 
     def test_classify_batch(self) -> None:


### PR DESCRIPTION
## Summary
- New `plugins.py` module queries sigild's `GET /api/v1/capabilities` for installed plugins, actions, and data sources
- Results cached 5 minutes, fails gracefully when sigild isn't running
- `ActivityClassifier` enhanced with richer plugin-source classification (GitHub PR→communicating, CI→verifying, Jira→communicating, Slack→communicating, Sentry→researching, IDE→editing)
- Dynamic fallback via capabilities API for unknown plugin sources
- New `GET /plugins` endpoint on sigil-ml server
- Depends on [sigil PR #35](https://github.com/sigil-tech/sigil/pull/35) for the capabilities HTTP endpoint

## Test plan
- [x] Plugin source classification tests for GitHub, Jira, Slack
- [x] GitHub PR events classified as communicating, default as integrating
- [x] All 55 tests pass
- [x] Graceful fallback when sigild not running (empty list, no crash)

Generated with [Claude Code](https://claude.com/claude-code)