### PR TITLE
Feature 001: Cloud Serving Mode

### DIFF
--- a/src/sigil_ml/app.py
+++ b/src/sigil_ml/app.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import Any
+from contextlib import asynccontextmanager
+from typing import Any, AsyncIterator
 
 from fastapi import FastAPI
 
@@ -109,17 +110,12 @@ def create_app(mode: ServingMode | None = None) -> FastAPI:
     if mode is None:
         mode = resolve_mode()  # reads SIGIL_ML_MODE env var, defaults to LOCAL
 
-    application = FastAPI(
-        title="sigil-ml",
-        version="0.1.0",
-        description=f"Sigil ML sidecar ({mode.value} mode)",
-    )
     state = AppState(mode=mode)
 
-    register_routes(application, state)
-
-    @application.on_event("startup")
-    async def startup_event() -> None:
+    @asynccontextmanager
+    async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+        """Manage startup and shutdown lifecycle for the application."""
+        # --- Startup ---
         if state.mode == ServingMode.LOCAL:
             store = create_store()
             state.store = store
@@ -168,14 +164,24 @@ def create_app(mode: ServingMode | None = None) -> FastAPI:
             state.model_loader = FilesystemModelLoader()
             logger.info("sigil-ml: cloud mode -- stateless serving, cache and loader initialized")
 
-    @application.on_event("shutdown")
-    async def shutdown_event() -> None:
+        yield
+
+        # --- Shutdown ---
         if state.poller:
             state.poller.stop()
             logger.info("poller stopped")
         if state.store:
             state.store.close()
             logger.info("store connection closed")
+
+    application = FastAPI(
+        title="sigil-ml",
+        version="0.1.0",
+        description=f"Sigil ML sidecar ({mode.value} mode)",
+        lifespan=lifespan,
+    )
+
+    register_routes(application, state)
 
     return application
 

--- a/src/sigil_ml/app.py
+++ b/src/sigil_ml/app.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from typing import Any
 
 from fastapi import FastAPI
 
+from sigil_ml.config import ServingMode, resolve_mode
 from sigil_ml.models.activity import ActivityClassifier
 from sigil_ml.models.duration import DurationEstimator
 from sigil_ml.models.quality import QualityEstimator
@@ -24,7 +26,8 @@ logger = logging.getLogger("sigil_ml")
 class AppState:
     """Holds model instances and runtime state, passed to routes."""
 
-    def __init__(self) -> None:
+    def __init__(self, mode: ServingMode = ServingMode.LOCAL) -> None:
+        self.mode = mode
         self.store: DataStore | None = None
         self.model_store: ModelStore | None = None
         self.stuck: StuckPredictor | None = None
@@ -34,6 +37,11 @@ class AppState:
         self.quality: QualityEstimator | None = None
         self.poller: EventPoller | None = None
         self.training_in_progress: bool = False
+        # Cloud-mode fields (initialized by cloud startup path)
+        self.model_cache: Any = None
+        self.model_loader: Any = None
+        # Per-tenant request counters (cloud mode, reset on restart)
+        self.request_counters: dict[str, int] = {}
 
     def load_models(self, model_store: ModelStore | None = None) -> None:
         """Load or reload all model instances."""
@@ -55,53 +63,110 @@ class AppState:
             self.poller.quality = self.quality
         logger.info("models reloaded into poller")
 
+    def resolve_model(self, tenant_id: str, model_name: str) -> Any | None:
+        """Resolve a model for the given tenant, using cache then loader.
 
-def create_app() -> FastAPI:
+        Returns the model object or None if no model is available.
+        Only used in cloud mode.
+        """
+        if self.model_cache is None or self.model_loader is None:
+            return None
+
+        # Check cache first
+        model = self.model_cache.get(tenant_id, model_name)
+        if model is not None:
+            logger.debug(
+                "model-resolve: cache_hit tenant=%s model=%s",
+                tenant_id, model_name,
+            )
+            return model
+
+        # Cache miss: load from backend
+        model = self.model_loader.load(tenant_id, model_name)
+        if model is not None:
+            self.model_cache.put(tenant_id, model_name, model)
+            logger.info(
+                "model-resolve: cache_miss+loaded tenant=%s model=%s",
+                tenant_id, model_name,
+            )
+            return model
+
+        logger.info(
+            "model-resolve: cache_miss+fallback tenant=%s model=%s",
+            tenant_id, model_name,
+        )
+        return None
+
+    def count_request(self, tenant_id: str) -> None:
+        """Increment the request counter for a tenant."""
+        self.request_counters[tenant_id] = (
+            self.request_counters.get(tenant_id, 0) + 1
+        )
+
+
+def create_app(mode: ServingMode | None = None) -> FastAPI:
     """Create and configure the FastAPI application."""
-    application = FastAPI(title="sigil-ml", version="0.1.0")
-    state = AppState()
+    if mode is None:
+        mode = resolve_mode()  # reads SIGIL_ML_MODE env var, defaults to LOCAL
+
+    application = FastAPI(
+        title="sigil-ml",
+        version="0.1.0",
+        description=f"Sigil ML sidecar ({mode.value} mode)",
+    )
+    state = AppState(mode=mode)
 
     register_routes(application, state)
 
     @application.on_event("startup")
     async def startup_event() -> None:
-        store = create_store()
-        state.store = store
+        if state.mode == ServingMode.LOCAL:
+            store = create_store()
+            state.store = store
 
-        ms = model_store_factory()
-        state.model_store = ms
+            ms = model_store_factory()
+            state.model_store = ms
 
-        logger.info("sigil-ml: using %s data backend, %s model backend", type(store).__name__, type(ms).__name__)
+            logger.info("sigil-ml: using %s data backend, %s model backend", type(store).__name__, type(ms).__name__)
 
-        try:
-            store.ensure_tables()
-        except Exception:
-            logger.warning("schema bootstrap failed (sigild may not have started yet)", exc_info=True)
+            try:
+                store.ensure_tables()
+            except Exception:
+                logger.warning("schema bootstrap failed (sigild may not have started yet)", exc_info=True)
 
-        state.load_models(ms)
+            state.load_models(ms)
 
-        state.poller = EventPoller(
-            store=store,
-            models={
-                "stuck": state.stuck,
-                "activity": state.activity,
-                "workflow": state.workflow,
-                "duration": state.duration,
-                "quality": state.quality,
-            },
-        )
-        asyncio.create_task(state.poller.run())
+            state.poller = EventPoller(
+                store=store,
+                models={
+                    "stuck": state.stuck,
+                    "activity": state.activity,
+                    "workflow": state.workflow,
+                    "duration": state.duration,
+                    "quality": state.quality,
+                },
+            )
+            asyncio.create_task(state.poller.run())
 
-        scheduler = TrainingScheduler(store, model_store=ms, reload_callback=state.reload_models_into_poller)
+            scheduler = TrainingScheduler(store, model_store=ms, reload_callback=state.reload_models_into_poller)
 
-        async def _schedule_loop():
-            while True:
-                await asyncio.get_event_loop().run_in_executor(None, scheduler.check_and_retrain)
-                await asyncio.sleep(600)
+            async def _schedule_loop():
+                while True:
+                    await asyncio.get_event_loop().run_in_executor(None, scheduler.check_and_retrain)
+                    await asyncio.sleep(600)
 
-        asyncio.create_task(_schedule_loop())
+            asyncio.create_task(_schedule_loop())
 
-        logger.info("sigil-ml: models loaded, poller started, scheduler active")
+            logger.info("sigil-ml: local mode -- models loaded, poller started, scheduler active")
+        else:
+            # Cloud mode: no SQLite, no poller, no scheduler.
+            # Models loaded lazily per-tenant via cache + loader.
+            from sigil_ml.cache import create_model_cache
+            from sigil_ml.loader import FilesystemModelLoader
+
+            state.model_cache = create_model_cache()
+            state.model_loader = FilesystemModelLoader()
+            logger.info("sigil-ml: cloud mode -- stateless serving, cache and loader initialized")
 
     @application.on_event("shutdown")
     async def shutdown_event() -> None:

--- a/src/sigil_ml/cache.py
+++ b/src/sigil_ml/cache.py
@@ -1,0 +1,179 @@
+"""In-memory model cache with TTL expiration and LRU eviction.
+
+Stores loaded model objects keyed by (tenant_id, model_name) with
+time-based expiration. Thread-safe for concurrent async access.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+import time
+from dataclasses import dataclass
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Type alias for cache key.
+CacheKey = tuple[str, str]  # (tenant_id, model_name)
+
+DEFAULT_TTL_SECONDS = 300.0
+DEFAULT_MAX_SIZE = 100
+
+
+@dataclass
+class _CacheEntry:
+    """Internal: a single cached model with creation timestamp."""
+
+    model: Any
+    loaded_at: float  # time.monotonic() timestamp
+
+
+class ModelCache:
+    """Thread-safe in-memory cache for tenant model objects.
+
+    Args:
+        ttl_seconds: Time-to-live for cache entries in seconds.
+        max_size: Maximum number of entries before LRU eviction.
+    """
+
+    def __init__(
+        self,
+        ttl_seconds: float = 300.0,
+        max_size: int = 100,
+    ) -> None:
+        self._entries: dict[CacheKey, _CacheEntry] = {}
+        self._ttl_seconds = ttl_seconds
+        self._max_size = max_size
+        self._lock = threading.Lock()
+        self._hits = 0
+        self._misses = 0
+        self._evictions = 0
+
+    def get(self, tenant_id: str, model_name: str) -> Any | None:
+        """Retrieve a model from cache.
+
+        Returns the model object on hit, None on miss or expiry.
+        """
+        key = (tenant_id, model_name)
+        with self._lock:
+            entry = self._entries.get(key)
+            if entry is None:
+                self._misses += 1
+                return None
+            age = time.monotonic() - entry.loaded_at
+            if age >= self._ttl_seconds:
+                del self._entries[key]
+                self._misses += 1
+                self._evictions += 1
+                return None
+            self._hits += 1
+            return entry.model
+
+    def put(
+        self, tenant_id: str, model_name: str, model: Any
+    ) -> None:
+        """Store a model in the cache.
+
+        If the cache is at capacity and the key is new, the oldest
+        entry is evicted first (LRU).
+        """
+        key = (tenant_id, model_name)
+        entry = _CacheEntry(model=model, loaded_at=time.monotonic())
+        with self._lock:
+            if key not in self._entries and len(self._entries) >= self._max_size:
+                self._evict_oldest_unlocked()
+            self._entries[key] = entry
+
+    def evict(self, tenant_id: str) -> int:
+        """Remove all entries for a tenant. Returns count removed."""
+        with self._lock:
+            keys = [k for k in self._entries if k[0] == tenant_id]
+            for k in keys:
+                del self._entries[k]
+            self._evictions += len(keys)
+            return len(keys)
+
+    def evict_all(self) -> int:
+        """Clear the entire cache. Returns count removed."""
+        with self._lock:
+            count = len(self._entries)
+            self._entries.clear()
+            self._evictions += count
+            return count
+
+    def cleanup_expired(self) -> int:
+        """Remove all expired entries. Returns count removed.
+
+        This is optional -- expiry is also checked lazily on get().
+        Useful for periodic maintenance to free memory.
+        """
+        now = time.monotonic()
+        with self._lock:
+            expired = [
+                k for k, v in self._entries.items()
+                if (now - v.loaded_at) >= self._ttl_seconds
+            ]
+            for k in expired:
+                del self._entries[k]
+            self._evictions += len(expired)
+            return len(expired)
+
+    def stats(self) -> dict[str, Any]:
+        """Return cache statistics for observability."""
+        with self._lock:
+            total = self._hits + self._misses
+            return {
+                "entries": len(self._entries),
+                "max_size": self._max_size,
+                "ttl_seconds": self._ttl_seconds,
+                "hits": self._hits,
+                "misses": self._misses,
+                "evictions": self._evictions,
+                "hit_rate": round(self._hits / total, 4) if total > 0 else 0.0,
+            }
+
+    def loaded_tenants(self) -> dict[str, list[str]]:
+        """Return mapping of tenant_id -> list of cached model names.
+
+        Only includes non-expired entries.
+        """
+        now = time.monotonic()
+        with self._lock:
+            result: dict[str, list[str]] = {}
+            for (tenant_id, model_name), entry in self._entries.items():
+                if (now - entry.loaded_at) < self._ttl_seconds:
+                    result.setdefault(tenant_id, []).append(model_name)
+            return result
+
+    def _evict_oldest_unlocked(self) -> None:
+        """Evict the entry with the oldest loaded_at timestamp.
+
+        MUST be called while holding self._lock.
+        """
+        if not self._entries:
+            return
+        oldest_key = min(
+            self._entries, key=lambda k: self._entries[k].loaded_at
+        )
+        del self._entries[oldest_key]
+        self._evictions += 1
+        logger.debug("cache: evicted oldest entry %s", oldest_key)
+
+
+def create_model_cache() -> ModelCache:
+    """Create a ModelCache with settings from environment variables.
+
+    Env vars:
+        MODEL_CACHE_TTL_SECONDS: TTL in seconds (default 300).
+        MODEL_CACHE_MAX_SIZE: Maximum entries (default 100).
+    """
+    ttl = float(
+        os.environ.get("MODEL_CACHE_TTL_SECONDS", str(DEFAULT_TTL_SECONDS))
+    )
+    max_size = int(
+        os.environ.get("MODEL_CACHE_MAX_SIZE", str(DEFAULT_MAX_SIZE))
+    )
+    logger.info("cache: created with ttl=%.0fs, max_size=%d", ttl, max_size)
+    return ModelCache(ttl_seconds=ttl, max_size=max_size)

--- a/src/sigil_ml/cli.py
+++ b/src/sigil_ml/cli.py
@@ -1,10 +1,12 @@
 """CLI entry point for sigil-ml."""
 
 import argparse
+import os
 import sys
 
 import uvicorn
 
+from sigil_ml.config import resolve_mode
 from sigil_ml.storage.model_store import model_store_factory
 from sigil_ml.store import create_store
 from sigil_ml.store_sqlite import SqliteStore
@@ -19,6 +21,12 @@ def main() -> None:
     serve_parser = sub.add_parser("serve", help="Start the ML server")
     serve_parser.add_argument("--host", default="127.0.0.1")
     serve_parser.add_argument("--port", type=int, default=7774)
+    serve_parser.add_argument(
+        "--mode",
+        choices=["local", "cloud"],
+        default=None,
+        help="Serving mode: 'local' (default, with poller) or 'cloud' (stateless, no SQLite)",
+    )
 
     train_parser = sub.add_parser("train", help="Train models from local data")
     train_parser.add_argument("--db", help="Path to sigild SQLite database")
@@ -28,6 +36,9 @@ def main() -> None:
     args = parser.parse_args()
 
     if args.command == "serve":
+        mode = resolve_mode(args.mode)
+        # Bridge mode to create_app() via env var (uvicorn string import cannot pass args)
+        os.environ["SIGIL_ML_MODE"] = mode.value
         uvicorn.run(
             "sigil_ml.app:app",
             host=args.host,

--- a/src/sigil_ml/cli.py
+++ b/src/sigil_ml/cli.py
@@ -272,11 +272,14 @@ def _build_cloud_training_config(
 
     return CloudTrainingConfig(
         min_interval_sec=min_interval
-        or int(os.environ.get("SIGIL_ML_TRAIN_MIN_INTERVAL", "3600")),
+        if min_interval is not None
+        else int(os.environ.get("SIGIL_ML_TRAIN_MIN_INTERVAL", "3600")),
         min_tasks=min_tasks
-        or int(os.environ.get("SIGIL_ML_TRAIN_MIN_TASKS", "10")),
+        if min_tasks is not None
+        else int(os.environ.get("SIGIL_ML_TRAIN_MIN_TASKS", "10")),
         max_tasks_per_tenant=max_tasks_per_tenant
-        or int(os.environ.get("SIGIL_ML_TRAIN_MAX_TASKS_PER_TENANT", "1000")),
+        if max_tasks_per_tenant is not None
+        else int(os.environ.get("SIGIL_ML_TRAIN_MAX_TASKS_PER_TENANT", "1000")),
     )
 
 

--- a/src/sigil_ml/cli.py
+++ b/src/sigil_ml/cli.py
@@ -1,6 +1,9 @@
 """CLI entry point for sigil-ml."""
 
+from __future__ import annotations
+
 import argparse
+import json
 import os
 import sys
 
@@ -30,6 +33,54 @@ def main() -> None:
 
     train_parser = sub.add_parser("train", help="Train models from local data")
     train_parser.add_argument("--db", help="Path to sigild SQLite database")
+    train_parser.add_argument(
+        "--mode",
+        choices=["local", "cloud"],
+        default="local",
+        help="Training mode: local (SQLite) or cloud (Postgres/S3)",
+    )
+    train_parser.add_argument(
+        "--tenant",
+        type=str,
+        default=None,
+        help="Train models for a specific tenant ID (cloud mode only)",
+    )
+    train_parser.add_argument(
+        "--all-tenants",
+        action="store_true",
+        default=False,
+        help="Discover and train all eligible tenants (cloud mode only)",
+    )
+    train_parser.add_argument(
+        "--aggregate",
+        action="store_true",
+        default=False,
+        help="Train aggregate model from pooled opted-in data (cloud mode only)",
+    )
+    train_parser.add_argument(
+        "--min-interval",
+        type=int,
+        default=None,
+        help="Minimum seconds between retraining a tenant (default: 3600)",
+    )
+    train_parser.add_argument(
+        "--min-tasks",
+        type=int,
+        default=None,
+        help="Minimum completed tasks for ML training (default: 10)",
+    )
+    train_parser.add_argument(
+        "--max-tasks-per-tenant",
+        type=int,
+        default=None,
+        help="Cap per-tenant tasks for aggregate training (default: 1000)",
+    )
+    train_parser.add_argument(
+        "--json",
+        action="store_true",
+        default=False,
+        help="Force compact JSON output (default for non-TTY)",
+    )
 
     sub.add_parser("health-check", help="Check if server is running")
 
@@ -46,17 +97,21 @@ def main() -> None:
             log_level="info",
         )
     elif args.command == "train":
-        if args.db:
-            from pathlib import Path
-
-            store = SqliteStore(Path(args.db))
+        if args.mode == "cloud":
+            _handle_cloud_training(args)
         else:
-            store = create_store()
-        ms = model_store_factory()
-        print(f"Training models using {type(store).__name__} + {type(ms).__name__} ...")
-        trainer = Trainer(store, model_store=ms)
-        result = trainer.train_all()
-        print(f"Done: {result}")
+            # Existing local training path -- COMPLETELY UNCHANGED
+            if args.db:
+                from pathlib import Path
+
+                store = SqliteStore(Path(args.db))
+            else:
+                store = create_store()
+            ms = model_store_factory()
+            print(f"Training models using {type(store).__name__} + {type(ms).__name__} ...")
+            trainer = Trainer(store, model_store=ms)
+            result = trainer.train_all()
+            print(f"Done: {result}")
     elif args.command == "health-check":
         try:
             import httpx
@@ -76,6 +131,153 @@ def main() -> None:
     else:
         parser.print_help()
         sys.exit(1)
+
+
+def _handle_cloud_training(args: argparse.Namespace) -> None:
+    """Handle all cloud training modes. Lazy-imports cloud modules."""
+    # Validate cloud flags: at least one target required
+    cloud_actions = [args.tenant, args.all_tenants, args.aggregate]
+    if not any(cloud_actions):
+        print(
+            "Error: Cloud mode requires --tenant, --all-tenants, or --aggregate",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    # Validate mutual exclusivity
+    if sum(bool(a) for a in cloud_actions) > 1:
+        print(
+            "Error: --tenant, --all-tenants, and --aggregate are mutually exclusive",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    # Validate cloud-only flags not used with local mode
+    # (already handled by routing -- only called when mode == "cloud")
+
+    # Validate required environment variables
+    db_url = os.environ.get("SIGIL_POSTGRES_URL")
+    s3_bucket = os.environ.get("SIGIL_S3_BUCKET")
+    if not db_url or not s3_bucket:
+        print(
+            "Error: SIGIL_POSTGRES_URL and SIGIL_S3_BUCKET environment variables "
+            "are required for cloud mode",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    # Construct stores from config (lazy imports)
+    from sigil_ml.training.cloud_trainer import CloudTrainer
+    from sigil_ml.training.models import CloudTrainingConfig
+
+    data_store = _create_data_store(db_url)
+    model_store = _create_model_store(s3_bucket)
+
+    cfg = _build_cloud_training_config(
+        min_interval=args.min_interval,
+        min_tasks=args.min_tasks,
+        max_tasks_per_tenant=args.max_tasks_per_tenant,
+    )
+
+    trainer = CloudTrainer(data_store, model_store, cfg)
+
+    use_compact_json = not sys.stdout.isatty() or args.json
+
+    if args.tenant:
+        result = trainer.train_tenant(args.tenant)
+        if use_compact_json:
+            print(json.dumps(result.to_dict()))
+        else:
+            print(json.dumps(result.to_dict(), indent=2))
+        sys.exit(0 if result.status != "failed" else 1)
+
+    elif args.all_tenants:
+        batch = trainer.train_all_tenants()
+        if use_compact_json:
+            print(json.dumps(batch.to_dict()))
+        else:
+            print(f"\n=== Batch Training Summary ===")
+            print(f"Total tenants: {batch.total}")
+            print(f"  Trained: {batch.trained}")
+            print(f"  Skipped: {batch.skipped}")
+            print(f"  Failed:  {batch.failed}")
+            print(f"Duration: {batch.total_duration_ms}ms")
+            if batch.failed > 0:
+                print(f"\nFailed tenants:")
+                for run in batch.runs:
+                    if run.status == "failed":
+                        print(f"  - {run.tenant_id}: {run.error}")
+            print(f"\nFull JSON:")
+            print(json.dumps(batch.to_dict(), indent=2))
+        sys.exit(0 if batch.failed == 0 else 1)
+
+    elif args.aggregate:
+        result = trainer.train_aggregate()
+        if use_compact_json:
+            print(json.dumps(result.to_dict()))
+        else:
+            print(f"\n=== Aggregate Training Summary ===")
+            print(f"Status: {result.status}")
+            print(f"Samples: {result.sample_count}")
+            print(f"Models trained: {', '.join(result.models_trained) or 'none'}")
+            print(f"Duration: {result.duration_ms}ms")
+            if result.error:
+                print(f"Note: {result.error}")
+            print(f"\nFull JSON:")
+            print(json.dumps(result.to_dict(), indent=2))
+        sys.exit(0 if result.status != "failed" else 1)
+
+
+def _create_data_store(db_url: str) -> object:
+    """Create a DataStore from the Postgres URL."""
+    try:
+        from sigil_ml.store_postgres import PostgresStore
+        from sigil_ml import config
+
+        tenant = config.tenant_id()
+        return PostgresStore(connection_url=db_url, tenant=tenant)
+    except ImportError:
+        raise SystemExit(
+            "Error: PostgresStore not available. "
+            "Install with: pip install sigil-ml[cloud]"
+        )
+
+
+def _create_model_store(s3_bucket_name: str) -> object:
+    """Create a ModelStore from the S3 bucket config."""
+    try:
+        from sigil_ml.storage.model_store import S3ModelStore
+        from sigil_ml import config
+
+        return S3ModelStore(
+            bucket=s3_bucket_name,
+            tenant_id=config.tenant_id(),
+            endpoint_url=config.s3_endpoint_url(),
+            region=config.aws_region(),
+        )
+    except ImportError:
+        raise SystemExit(
+            "Error: S3ModelStore not available. "
+            "Install with: pip install sigil-ml[cloud]"
+        )
+
+
+def _build_cloud_training_config(
+    min_interval: int | None = None,
+    min_tasks: int | None = None,
+    max_tasks_per_tenant: int | None = None,
+) -> object:
+    """Build a CloudTrainingConfig from env vars with CLI overrides."""
+    from sigil_ml.training.models import CloudTrainingConfig
+
+    return CloudTrainingConfig(
+        min_interval_sec=min_interval
+        or int(os.environ.get("SIGIL_ML_TRAIN_MIN_INTERVAL", "3600")),
+        min_tasks=min_tasks
+        or int(os.environ.get("SIGIL_ML_TRAIN_MIN_TASKS", "10")),
+        max_tasks_per_tenant=max_tasks_per_tenant
+        or int(os.environ.get("SIGIL_ML_TRAIN_MAX_TASKS_PER_TENANT", "1000")),
+    )
 
 
 if __name__ == "__main__":

--- a/src/sigil_ml/config.py
+++ b/src/sigil_ml/config.py
@@ -2,8 +2,42 @@
 
 from __future__ import annotations
 
+import enum
 import os
 from pathlib import Path
+
+
+class ServingMode(str, enum.Enum):
+    """Operating mode for the sigil-ml service.
+
+    LOCAL: Default. Poller, SQLite, local models. Current behavior.
+    CLOUD: Stateless. No poller, no SQLite, tenant-aware model loading.
+    """
+
+    LOCAL = "local"
+    CLOUD = "cloud"
+
+
+def resolve_mode(cli_mode: str | None = None) -> ServingMode:
+    """Resolve the serving mode from CLI flag or environment.
+
+    Priority:
+      1. cli_mode argument (from --mode flag)
+      2. SIGIL_ML_MODE environment variable
+      3. Default: LOCAL
+
+    Raises:
+        SystemExit: If the provided mode value is invalid.
+    """
+    raw = cli_mode or os.environ.get("SIGIL_ML_MODE", "local")
+    if not raw or not raw.strip():
+        raw = "local"
+    try:
+        return ServingMode(raw.strip().lower())
+    except ValueError:
+        raise SystemExit(
+            f"Invalid serving mode: {raw!r}. Must be 'local' or 'cloud'."
+        )
 
 
 def _data_home() -> Path:

--- a/src/sigil_ml/config.py
+++ b/src/sigil_ml/config.py
@@ -120,3 +120,16 @@ def aws_region() -> str | None:
 def model_cache_ttl() -> float:
     """Return the model cache TTL in seconds. Default 300."""
     return float(os.environ.get("SIGIL_MODEL_CACHE_TTL", "300"))
+
+
+import re
+
+_TENANT_ID_RE = re.compile(r"^[a-z0-9_-]{1,63}$")
+
+
+def validate_tenant_id(tenant_id: str) -> bool:
+    """Return True if tenant_id matches the allowed format.
+
+    Valid: 1-63 characters of lowercase alphanumeric, hyphens, underscores.
+    """
+    return bool(_TENANT_ID_RE.match(tenant_id))

--- a/src/sigil_ml/features.py
+++ b/src/sigil_ml/features.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 import json
 import math
 import time
+from typing import Any
+
 from sigil_ml.store import DataStore
 
 # --- Activity classification features ---
@@ -325,3 +327,104 @@ def extract_workflow_features(classified_events: list[dict], session_info: dict)
     features["test_failures"] = float(session_info.get("test_failures", 0))
 
     return features
+
+
+# ---------------------------------------------------------------------------
+# Cloud-mode feature extractors: accept pre-queried data (task dict + events)
+# instead of a DataStore + task_id. Produce identical output to the DataStore-
+# based extractors above.
+# ---------------------------------------------------------------------------
+
+
+def extract_stuck_features_from_data(
+    task: dict[str, Any], events: list[dict[str, Any]]
+) -> dict[str, float]:
+    """Extract stuck features from pre-queried task and events data.
+
+    Same output as extract_stuck_features() but operates on passed-in
+    data instead of querying a DataStore. For use with DataStore in cloud mode.
+    """
+    now_ms = int(time.time() * 1000)
+    started_at = task.get("started_at", now_ms)
+    last_active = task.get("last_active", now_ms)
+    session_length_sec = max((last_active - started_at) / 1000.0, 1.0)
+    test_failure_count = float(task.get("test_fails", 0) or 0)
+
+    # Time in current phase: approximate from last phase-change event or started_at
+    phase_start = started_at
+    for ev in events:
+        if ev.get("kind") == "phase_change":
+            phase_start = ev.get("ts", phase_start)
+    time_in_phase_sec = (now_ms - phase_start) / 1000.0
+
+    # Edit velocity: count edit events
+    edit_events = [e for e in events if e.get("kind") in ("edit", "file_edit", "save")]
+    edit_count = len(edit_events)
+    session_minutes = max(session_length_sec / 60.0, 1 / 60.0)
+    edit_velocity = edit_count / session_minutes
+
+    # File switch rate: distinct files / total edits
+    files_in_edits: set[str] = set()
+    for ev in edit_events:
+        payload = ev.get("payload")
+        if isinstance(payload, dict) and "file" in payload:
+            files_in_edits.add(payload["file"])
+    file_switch_rate = len(files_in_edits) / max(edit_count, 1)
+
+    # Time since last commit
+    commit_events = [e for e in events if e.get("kind") == "commit"]
+    if commit_events:
+        last_commit_ts = max(e.get("ts", 0) for e in commit_events)
+        time_since_last_commit_sec = (now_ms - last_commit_ts) / 1000.0
+    else:
+        time_since_last_commit_sec = session_length_sec
+
+    return {
+        "test_failure_count": test_failure_count,
+        "time_in_phase_sec": time_in_phase_sec,
+        "edit_velocity": edit_velocity,
+        "file_switch_rate": file_switch_rate,
+        "session_length_sec": session_length_sec,
+        "time_since_last_commit_sec": time_since_last_commit_sec,
+    }
+
+
+def extract_duration_features_from_data(
+    task: dict[str, Any], events: list[dict[str, Any]]
+) -> dict[str, float]:
+    """Extract duration features from pre-queried data.
+
+    Same output as extract_duration_features() but operates on passed-in
+    data instead of querying a DataStore. For use with DataStore in cloud mode.
+    """
+    # File count
+    files_map = task.get("files")
+    if isinstance(files_map, str):
+        try:
+            files_map = json.loads(files_map)
+        except (json.JSONDecodeError, TypeError):
+            files_map = {}
+    file_count = float(len(files_map)) if isinstance(files_map, dict) else 0.0
+
+    # Total edits from events
+    total_edits = float(
+        len([e for e in events if e.get("kind") in ("edit", "file_edit", "save")])
+    )
+
+    # Time of day
+    started_at = task.get("started_at")
+    if started_at:
+        hour = time.localtime(started_at / 1000.0).tm_hour
+    else:
+        hour = time.localtime().tm_hour
+
+    # Branch name length
+    branch = task.get("branch") or ""
+    branch_name_length = float(len(branch))
+
+    return {
+        "file_count": file_count,
+        "total_edits": total_edits,
+        "time_of_day_hour": float(hour),
+        "branch_name_length": branch_name_length,
+    }

--- a/src/sigil_ml/loader.py
+++ b/src/sigil_ml/loader.py
@@ -62,8 +62,6 @@ class FilesystemModelLoader:
         Tries tenant-specific path first, then shared path.
         Returns None if neither exists or if loading fails.
         """
-        import joblib
-
         # Tenant-specific path
         tenant_path = self._base_dir / tenant_id / f"{model_name}.joblib"
         if tenant_path.exists():

--- a/src/sigil_ml/loader.py
+++ b/src/sigil_ml/loader.py
@@ -1,0 +1,104 @@
+"""Model loading interface for pluggable storage backends.
+
+Defines the ModelLoader protocol that storage backends must implement.
+Feature 003 (Model Storage Abstraction) will provide an S3 implementation.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any, Protocol, runtime_checkable
+
+logger = logging.getLogger(__name__)
+
+
+@runtime_checkable
+class ModelLoader(Protocol):
+    """Protocol for loading model objects from a storage backend.
+
+    Implementations must:
+    - Handle tenant-specific model resolution.
+    - Return None when no model exists (not raise exceptions).
+    - Be thread-safe (may be called concurrently).
+    """
+
+    def load(self, tenant_id: str, model_name: str) -> Any | None:
+        """Load a model for the given tenant and model name.
+
+        Args:
+            tenant_id: Tenant identifier.
+            model_name: One of "stuck", "suggest", "workflow",
+                        "duration", "activity", "quality".
+
+        Returns:
+            The loaded model object, or None if not found.
+        """
+        ...
+
+
+class FilesystemModelLoader:
+    """Loads model weights from the local filesystem.
+
+    Directory layout:
+        {models_dir}/{tenant_id}/{model_name}.joblib  (tenant-specific)
+        {models_dir}/{model_name}.joblib               (shared fallback)
+    """
+
+    def __init__(self, base_dir: Path | None = None) -> None:
+        """Initialize with the base directory for model weights.
+
+        Args:
+            base_dir: Root directory. Defaults to config.models_dir().
+        """
+        if base_dir is None:
+            from sigil_ml import config
+            base_dir = config.models_dir()
+        self._base_dir = base_dir
+
+    def load(self, tenant_id: str, model_name: str) -> Any | None:
+        """Load a model from the filesystem.
+
+        Tries tenant-specific path first, then shared path.
+        Returns None if neither exists or if loading fails.
+        """
+        import joblib
+
+        # Tenant-specific path
+        tenant_path = self._base_dir / tenant_id / f"{model_name}.joblib"
+        if tenant_path.exists():
+            return self._safe_load(tenant_path, tenant_id, model_name)
+
+        # Shared model fallback (no tenant directory)
+        shared_path = self._base_dir / f"{model_name}.joblib"
+        if shared_path.exists():
+            logger.info(
+                "loader: using shared model for %s/%s",
+                tenant_id, model_name,
+            )
+            return self._safe_load(shared_path, tenant_id, model_name)
+
+        logger.debug(
+            "loader: no model found for %s/%s", tenant_id, model_name
+        )
+        return None
+
+    def _safe_load(
+        self, path: Path, tenant_id: str, model_name: str
+    ) -> Any | None:
+        """Load a joblib file with error handling."""
+        import joblib
+
+        try:
+            model = joblib.load(path)
+            logger.info(
+                "loader: loaded %s/%s from %s", tenant_id, model_name, path
+            )
+            return model
+        except Exception:
+            logger.warning(
+                "loader: failed to load %s/%s from %s",
+                tenant_id, model_name, path,
+                exc_info=True,
+            )
+            return None

--- a/src/sigil_ml/models/activity.py
+++ b/src/sigil_ml/models/activity.py
@@ -104,6 +104,20 @@ class ActivityClassifier:
                 logger.warning("Failed to load activity classifier, using rules")
                 self._ml_model = None
 
+    @classmethod
+    def from_trained_model(
+        cls, model: SGDClassifier, store: ModelStore | None = None
+    ) -> ActivityClassifier:
+        """Create an instance from an already-trained sklearn model.
+
+        Use this instead of ``__new__`` to avoid bypassing ``__init__``.
+        """
+        instance = object.__new__(cls)
+        instance._store = store or LocalModelStore()
+        instance._ml_model = model
+        instance._trained = True
+        return instance
+
     @property
     def is_trained(self) -> bool:
         return self._trained

--- a/src/sigil_ml/models/duration.py
+++ b/src/sigil_ml/models/duration.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import io
 import logging
+from typing import Any
 
 import joblib
 import numpy as np
@@ -38,11 +39,25 @@ class DurationEstimator:
                 logger.warning("Failed to load duration model, starting fresh")
                 self.model = None
 
+    @classmethod
+    def from_trained_model(
+        cls, model: GradientBoostingRegressor, store: ModelStore | None = None
+    ) -> DurationEstimator:
+        """Create an instance from an already-trained sklearn model.
+
+        Use this instead of ``__new__`` to avoid bypassing ``__init__``.
+        """
+        instance = object.__new__(cls)
+        instance._store = store or LocalModelStore()
+        instance.model = model
+        instance._trained = True
+        return instance
+
     @property
     def is_trained(self) -> bool:
         return self._trained
 
-    def predict(self, features: dict) -> dict:
+    def predict(self, features: dict[str, float]) -> dict[str, Any]:
         """Predict task duration from feature dict.
 
         Returns:

--- a/src/sigil_ml/models/quality.py
+++ b/src/sigil_ml/models/quality.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import logging
+from typing import Any
 
 import numpy as np
 
@@ -44,6 +45,23 @@ class QualityEstimator:
         self.weights = dict(DEFAULT_WEIGHTS)
         self._load_weights()
 
+    @classmethod
+    def from_trained_model(
+        cls, weights: dict[str, int] | None = None, store: ModelStore | None = None
+    ) -> QualityEstimator:
+        """Create an instance from pre-configured weights.
+
+        Use this instead of ``__new__`` to avoid bypassing ``__init__``.
+
+        Args:
+            weights: Component weights dict. Uses DEFAULT_WEIGHTS if None.
+            store: Optional ModelStore for persistence.
+        """
+        instance = object.__new__(cls)
+        instance._store = store or LocalModelStore()
+        instance.weights = dict(weights if weights is not None else DEFAULT_WEIGHTS)
+        return instance
+
     def _load_weights(self) -> None:
         data = self._store.load("quality")
         if data is not None:
@@ -58,7 +76,7 @@ class QualityEstimator:
         data = json.dumps({"weights": self.weights}).encode("utf-8")
         self._store.save("quality", data)
 
-    def predict(self, features: dict) -> dict:
+    def predict(self, features: dict[str, float]) -> dict[str, Any]:
         """Compute quality score from rolling window features.
 
         Features:

--- a/src/sigil_ml/models/stuck.py
+++ b/src/sigil_ml/models/stuck.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import io
 import logging
+from typing import Any
 
 import joblib
 import numpy as np
@@ -40,11 +41,25 @@ class StuckPredictor:
                 logger.warning("Failed to load stuck model weights, starting fresh")
                 self.model = None
 
+    @classmethod
+    def from_trained_model(
+        cls, model: GradientBoostingClassifier, store: ModelStore | None = None
+    ) -> StuckPredictor:
+        """Create an instance from an already-trained sklearn model.
+
+        Use this instead of ``__new__`` to avoid bypassing ``__init__``.
+        """
+        instance = object.__new__(cls)
+        instance._store = store or LocalModelStore()
+        instance.model = model
+        instance._trained = True
+        return instance
+
     @property
     def is_trained(self) -> bool:
         return self._trained
 
-    def predict(self, features: dict) -> dict:
+    def predict(self, features: dict[str, float]) -> dict[str, Any]:
         """Predict stuck probability from feature dict.
 
         Returns:

--- a/src/sigil_ml/models/workflow.py
+++ b/src/sigil_ml/models/workflow.py
@@ -54,6 +54,20 @@ class WorkflowStatePredictor:
                 logger.warning("Failed to load workflow model, using rules")
                 self._ml_model = None
 
+    @classmethod
+    def from_trained_model(
+        cls, model: GradientBoostingClassifier, store: ModelStore | None = None
+    ) -> WorkflowStatePredictor:
+        """Create an instance from an already-trained sklearn model.
+
+        Use this instead of ``__new__`` to avoid bypassing ``__init__``.
+        """
+        instance = object.__new__(cls)
+        instance._store = store or LocalModelStore()
+        instance._ml_model = model
+        instance._trained = True
+        return instance
+
     @property
     def is_trained(self) -> bool:
         return self._trained

--- a/src/sigil_ml/poller.py
+++ b/src/sigil_ml/poller.py
@@ -10,6 +10,7 @@ import asyncio
 import json
 import logging
 import time
+from typing import Any
 
 from sigil_ml.features import (
     extract_duration_features,
@@ -31,7 +32,7 @@ QUALITY_TTL_SEC = 120  # 2-minute expiry for quality
 class EventPoller:
     """Polls sigild's events table and writes predictions to ml_predictions."""
 
-    def __init__(self, store: DataStore, models: dict) -> None:
+    def __init__(self, store: DataStore, models: dict[str, Any]) -> None:
         self.store = store
         self.stuck = models["stuck"]
         self.activity = models["activity"]

--- a/src/sigil_ml/routes.py
+++ b/src/sigil_ml/routes.py
@@ -9,7 +9,6 @@ from typing import TYPE_CHECKING
 from fastapi import BackgroundTasks, Depends, FastAPI, HTTPException
 from pydantic import BaseModel, Field
 
-from sigil_ml import config
 from sigil_ml.config import ServingMode
 from sigil_ml.features import extract_duration_features, extract_stuck_features
 from sigil_ml.models.stuck import StuckPredictor

--- a/src/sigil_ml/routes.py
+++ b/src/sigil_ml/routes.py
@@ -232,10 +232,7 @@ def register_routes(fastapi_app: FastAPI, state: AppState) -> None:
             if model is None:
                 return FALLBACK_STUCK
 
-            # Use wrapper to get prediction from resolved model
-            predictor = StuckPredictor.__new__(StuckPredictor)
-            predictor.model = model
-            predictor._trained = True
+            predictor = StuckPredictor.from_trained_model(model)
             result = predictor.predict(req.features)
             return StuckResponse(**result)
 
@@ -271,14 +268,10 @@ def register_routes(fastapi_app: FastAPI, state: AppState) -> None:
 
             model = state.resolve_model(tenant.tenant_id, "workflow")
             if model is None:
-                # Use rules-based fallback via a fresh predictor
-                predictor = WorkflowStatePredictor.__new__(WorkflowStatePredictor)
-                predictor._ml_model = None
-                predictor._trained = False
+                # Use rules-based fallback via a fresh predictor (no model store load)
+                predictor = WorkflowStatePredictor()
             else:
-                predictor = WorkflowStatePredictor.__new__(WorkflowStatePredictor)
-                predictor._ml_model = model
-                predictor._trained = True
+                predictor = WorkflowStatePredictor.from_trained_model(model)
 
             session_info = {
                 "session_elapsed_min": 0.0,
@@ -337,10 +330,7 @@ def register_routes(fastapi_app: FastAPI, state: AppState) -> None:
             if model is None:
                 return FALLBACK_DURATION
 
-            # Use wrapper to get prediction from resolved model
-            predictor = DurationEstimator.__new__(DurationEstimator)
-            predictor.model = model
-            predictor._trained = True
+            predictor = DurationEstimator.from_trained_model(model)
             result = predictor.predict(req.features)
             return DurationResponse(**result)
 
@@ -368,14 +358,7 @@ def register_routes(fastapi_app: FastAPI, state: AppState) -> None:
         if state.mode == ServingMode.CLOUD:
             state.count_request(tenant.tenant_id)
             # Quality is rule-based, no per-tenant model needed
-            estimator = QualityEstimator.__new__(QualityEstimator)
-            estimator.weights = {
-                "test_pass_rate": 30,
-                "edit_focus": 20,
-                "velocity_vs_baseline": 20,
-                "commit_frequency": 15,
-                "no_revert_penalty": 15,
-            }
+            estimator = QualityEstimator.from_trained_model()
             result = estimator.predict(req.features)
             return QualityResponse(
                 score=result["score"],

--- a/src/sigil_ml/routes.py
+++ b/src/sigil_ml/routes.py
@@ -6,11 +6,18 @@ import logging
 import time
 from typing import TYPE_CHECKING
 
-from fastapi import BackgroundTasks, FastAPI
+from fastapi import BackgroundTasks, Depends, FastAPI, HTTPException
 from pydantic import BaseModel, Field
 
+from sigil_ml import config
+from sigil_ml.config import ServingMode
 from sigil_ml.features import extract_duration_features, extract_stuck_features
+from sigil_ml.models.stuck import StuckPredictor
+from sigil_ml.models.workflow import WorkflowStatePredictor
+from sigil_ml.models.duration import DurationEstimator
+from sigil_ml.models.quality import QualityEstimator
 from sigil_ml.plugins import fetch_capabilities
+from sigil_ml.tenant import TenantContext, make_tenant_dependency
 from sigil_ml.training.trainer import Trainer
 
 if TYPE_CHECKING:
@@ -80,11 +87,44 @@ class TrainResponse(BaseModel):
 
 class HealthResponse(BaseModel):
     status: str
+    mode: str = "local"  # Default for backward compatibility
     models: dict[str, str]
     uptime_sec: float
 
 
 _start_time = time.time()
+
+
+# ---------- Centralized fallback predictions for cloud mode ----------
+# These match existing fallbacks in poller.py and routes.py.
+
+FALLBACK_STUCK = StuckResponse(probability=0.5, confidence="weak")
+
+FALLBACK_SUGGEST = WorkflowStateResponse(
+    flow_state={
+        "shallow_work": 1.0,
+        "deep_work": 0.0,
+        "exploring": 0.0,
+        "blocked": 0.0,
+        "winding_down": 0.0,
+    },
+    dominant_state="shallow_work",
+    momentum=0.0,
+    focus_score=0.5,
+    dominant_activity="idle",
+    activity_distribution={},
+    session_elapsed_min=0.0,
+    method="rules",
+    confidence=0.5,
+)
+
+FALLBACK_DURATION = DurationResponse(
+    estimated_minutes=60.0, confidence_interval=[30.0, 90.0]
+)
+
+FALLBACK_QUALITY = QualityResponse(
+    score=50, components={}, status="normal"
+)
 
 
 # ---------- Route registration ----------
@@ -93,8 +133,33 @@ _start_time = time.time()
 def register_routes(fastapi_app: FastAPI, state: AppState) -> None:
     """Register all API routes on the given FastAPI app."""
 
+    get_tenant = make_tenant_dependency(state)
+
     @fastapi_app.get("/health", response_model=HealthResponse)
     async def health() -> HealthResponse:
+        if state.mode == ServingMode.CLOUD:
+            models_status: dict[str, str] = {}
+            if state.model_cache:
+                tenants = state.model_cache.loaded_tenants()
+                all_cached_models: set[str] = set()
+                for model_list in tenants.values():
+                    all_cached_models.update(model_list)
+                for name in ["stuck", "activity", "workflow", "duration", "quality"]:
+                    models_status[name] = (
+                        "cached" if name in all_cached_models else "on_demand"
+                    )
+            else:
+                for name in ["stuck", "activity", "workflow", "duration", "quality"]:
+                    models_status[name] = "not_initialized"
+
+            return HealthResponse(
+                status="ok",
+                mode="cloud",
+                models=models_status,
+                uptime_sec=round(time.time() - _start_time, 1),
+            )
+
+        # Local mode: existing behavior with mode field added
         models_status = {}
         for name, model in [
             ("stuck", state.stuck),
@@ -111,24 +176,70 @@ def register_routes(fastapi_app: FastAPI, state: AppState) -> None:
 
         return HealthResponse(
             status="ok",
+            mode="local",
             models=models_status,
             uptime_sec=round(time.time() - _start_time, 1),
         )
 
     @fastapi_app.get("/status")
     async def status() -> dict:
+        if state.mode == ServingMode.CLOUD:
+            cache_stats = (
+                state.model_cache.stats() if state.model_cache else {}
+            )
+            loaded = (
+                state.model_cache.loaded_tenants()
+                if state.model_cache
+                else {}
+            )
+            return {
+                "mode": "cloud",
+                "cache": cache_stats,
+                "loaded_tenants": loaded,
+                "request_counts": dict(state.request_counters),
+                "poller_running": False,
+            }
+
+        # Local mode: existing SQLite-based status (unchanged)
         try:
             status_data = state.store.get_status_data()
             return {
+                "mode": "local",
                 "cursor": status_data["cursor"],
                 "latest_predictions": status_data["latest_predictions"],
                 "poller_running": state.poller is not None and state.poller._running,
             }
         except Exception:
-            return {"cursor": None, "latest_predictions": [], "poller_running": False}
+            return {"mode": "local", "cursor": None, "latest_predictions": [], "poller_running": False}
 
     @fastapi_app.post("/predict/stuck", response_model=StuckResponse)
-    async def predict_stuck(req: StuckRequest) -> StuckResponse:
+    async def predict_stuck(
+        req: StuckRequest,
+        tenant: TenantContext = Depends(get_tenant),
+    ) -> StuckResponse:
+        if state.mode == ServingMode.CLOUD:
+            state.count_request(tenant.tenant_id)
+            if req.features is None:
+                if req.task_id is not None:
+                    raise HTTPException(
+                        status_code=400,
+                        detail="Cloud mode requires 'features' in request body. "
+                               "'task_id' lookup is not available without SQLite.",
+                    )
+                return FALLBACK_STUCK
+
+            model = state.resolve_model(tenant.tenant_id, "stuck")
+            if model is None:
+                return FALLBACK_STUCK
+
+            # Use wrapper to get prediction from resolved model
+            predictor = StuckPredictor.__new__(StuckPredictor)
+            predictor.model = model
+            predictor._trained = True
+            result = predictor.predict(req.features)
+            return StuckResponse(**result)
+
+        # Local mode: unchanged
         if state.stuck is None:
             return StuckResponse(probability=0.5, confidence="weak")
 
@@ -143,7 +254,41 @@ def register_routes(fastapi_app: FastAPI, state: AppState) -> None:
         return StuckResponse(**result)
 
     @fastapi_app.post("/predict/suggest", response_model=WorkflowStateResponse)
-    async def predict_suggest(req: WorkflowStateRequest) -> WorkflowStateResponse:
+    async def predict_suggest(
+        req: WorkflowStateRequest,
+        tenant: TenantContext = Depends(get_tenant),
+    ) -> WorkflowStateResponse:
+        if state.mode == ServingMode.CLOUD:
+            state.count_request(tenant.tenant_id)
+            classified_events = req.classified_events or []
+
+            if not classified_events:
+                raise HTTPException(
+                    status_code=400,
+                    detail="Cloud mode requires 'classified_events' in request body. "
+                           "Poller buffer is not available.",
+                )
+
+            model = state.resolve_model(tenant.tenant_id, "workflow")
+            if model is None:
+                # Use rules-based fallback via a fresh predictor
+                predictor = WorkflowStatePredictor.__new__(WorkflowStatePredictor)
+                predictor._ml_model = None
+                predictor._trained = False
+            else:
+                predictor = WorkflowStatePredictor.__new__(WorkflowStatePredictor)
+                predictor._ml_model = model
+                predictor._trained = True
+
+            session_info = {
+                "session_elapsed_min": 0.0,
+                "task_phase": None,
+                "test_failures": 0,
+            }
+            result = predictor.predict(classified_events, session_info)
+            return WorkflowStateResponse(**result)
+
+        # Local mode: unchanged
         if state.workflow is None:
             return WorkflowStateResponse(
                 flow_state={
@@ -173,7 +318,33 @@ def register_routes(fastapi_app: FastAPI, state: AppState) -> None:
         return WorkflowStateResponse(**result)
 
     @fastapi_app.post("/predict/duration", response_model=DurationResponse)
-    async def predict_duration(req: DurationRequest) -> DurationResponse:
+    async def predict_duration(
+        req: DurationRequest,
+        tenant: TenantContext = Depends(get_tenant),
+    ) -> DurationResponse:
+        if state.mode == ServingMode.CLOUD:
+            state.count_request(tenant.tenant_id)
+            if req.features is None:
+                if req.task_id is not None:
+                    raise HTTPException(
+                        status_code=400,
+                        detail="Cloud mode requires 'features' in request body. "
+                               "'task_id' lookup is not available without SQLite.",
+                    )
+                return FALLBACK_DURATION
+
+            model = state.resolve_model(tenant.tenant_id, "duration")
+            if model is None:
+                return FALLBACK_DURATION
+
+            # Use wrapper to get prediction from resolved model
+            predictor = DurationEstimator.__new__(DurationEstimator)
+            predictor.model = model
+            predictor._trained = True
+            result = predictor.predict(req.features)
+            return DurationResponse(**result)
+
+        # Local mode: unchanged
         if state.duration is None:
             return DurationResponse(estimated_minutes=60.0, confidence_interval=[30.0, 90.0])
 
@@ -187,8 +358,32 @@ def register_routes(fastapi_app: FastAPI, state: AppState) -> None:
         result = state.duration.predict(features)
         return DurationResponse(**result)
 
+    # Cloud-safe: QualityRequest.features is required (no task_id lookup path).
+    # QualityEstimator.predict() is purely functional, no DB access.
     @fastapi_app.post("/predict/quality", response_model=QualityResponse)
-    async def predict_quality(req: QualityRequest) -> QualityResponse:
+    async def predict_quality(
+        req: QualityRequest,
+        tenant: TenantContext = Depends(get_tenant),
+    ) -> QualityResponse:
+        if state.mode == ServingMode.CLOUD:
+            state.count_request(tenant.tenant_id)
+            # Quality is rule-based, no per-tenant model needed
+            estimator = QualityEstimator.__new__(QualityEstimator)
+            estimator.weights = {
+                "test_pass_rate": 30,
+                "edit_focus": 20,
+                "velocity_vs_baseline": 20,
+                "commit_frequency": 15,
+                "no_revert_penalty": 15,
+            }
+            result = estimator.predict(req.features)
+            return QualityResponse(
+                score=result["score"],
+                components=result["components"],
+                status=result["status"],
+            )
+
+        # Local mode: unchanged
         if state.quality is None:
             return QualityResponse(score=50, components={}, status="normal")
 
@@ -205,11 +400,26 @@ def register_routes(fastapi_app: FastAPI, state: AppState) -> None:
 
     @fastapi_app.post("/train", response_model=TrainResponse)
     async def train(req: TrainRequest, background_tasks: BackgroundTasks) -> TrainResponse:
+        if state.mode == ServingMode.CLOUD:
+            raise HTTPException(
+                status_code=405,
+                detail="Training is not supported in cloud mode. "
+                       "Train models via the training pipeline and deploy weights to storage.",
+            )
+
         if state.training_in_progress:
             return TrainResponse(status="busy", message="Training already in progress")
 
         background_tasks.add_task(_run_training, state)
         return TrainResponse(status="started", message="Training started")
+
+    @fastapi_app.get("/")
+    async def root() -> dict:
+        return {
+            "service": "sigil-ml",
+            "mode": state.mode.value,
+            "version": "0.1.0",
+        }
 
 
 def _run_training(state: AppState) -> None:

--- a/src/sigil_ml/storage/model_store.py
+++ b/src/sigil_ml/storage/model_store.py
@@ -49,6 +49,7 @@ class LocalModelStore:
         return self._base_dir / f"{model_name}.joblib"
 
     def load(self, model_name: str) -> bytes | None:
+        """Load model weights from disk. Returns None if the file does not exist."""
         path = self._path(model_name)
         if not path.exists():
             return None
@@ -59,11 +60,13 @@ class LocalModelStore:
             return None
 
     def save(self, model_name: str, data: bytes) -> None:
+        """Save model weights to disk, creating parent directories as needed."""
         path = self._path(model_name)
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_bytes(data)
 
     def exists(self, model_name: str) -> bool:
+        """Return True if the model weight file exists on disk."""
         return self._path(model_name).exists()
 
 
@@ -121,6 +124,7 @@ class S3ModelStore:
         return f"{self._tenant_id}/models/{model_name}/{version}/model.joblib"
 
     def load(self, model_name: str) -> bytes | None:
+        """Load model weights from S3 by resolving the latest version pointer."""
         try:
             # Read the latest pointer to get the version
             resp = self._s3.get_object(Bucket=self._bucket, Key=self._latest_key(model_name))
@@ -138,6 +142,7 @@ class S3ModelStore:
             return None
 
     def save(self, model_name: str, data: bytes) -> None:
+        """Save model weights to S3 with a timestamped version and update the latest pointer."""
         from datetime import datetime, timezone
 
         version = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
@@ -157,6 +162,7 @@ class S3ModelStore:
         )
 
     def exists(self, model_name: str) -> bool:
+        """Return True if a latest-version pointer exists for this model in S3."""
         try:
             self._s3.head_object(Bucket=self._bucket, Key=self._latest_key(model_name))
             return True
@@ -184,6 +190,7 @@ class CachedModelStore:
         self._lock = threading.Lock()
 
     def load(self, model_name: str) -> bytes | None:
+        """Load from cache if fresh, otherwise delegate to the inner store and cache the result."""
         now = time.monotonic()
         with self._lock:
             if model_name in self._cache:
@@ -204,12 +211,14 @@ class CachedModelStore:
         return data
 
     def save(self, model_name: str, data: bytes) -> None:
+        """Save to the inner store and update the cache."""
         self._inner.save(model_name, data)
         with self._lock:
             self._evict_if_full()
             self._cache[model_name] = (data, time.monotonic())
 
     def exists(self, model_name: str) -> bool:
+        """Check cache first; fall back to inner store if not cached or expired."""
         with self._lock:
             if model_name in self._cache:
                 _, cached_at = self._cache[model_name]

--- a/src/sigil_ml/store.py
+++ b/src/sigil_ml/store.py
@@ -104,6 +104,32 @@ class DataStore(Protocol):
         """Close the underlying database connection."""
         ...
 
+    # --- Cloud training methods ---
+
+    def get_last_training_ts(self, tenant_id: str) -> float | None:
+        """Return the last training timestamp (epoch ms) for a tenant, or None if never trained."""
+        ...
+
+    def get_completed_tasks_for_tenant(self, tenant_id: str) -> list[dict]:
+        """Return completed tasks for a specific tenant (cloud multi-tenant queries)."""
+        ...
+
+    def get_events_for_task_id(self, task_id: str) -> list[dict]:
+        """Return events associated with a specific task ID."""
+        ...
+
+    def get_all_tenant_ids(self) -> list[str]:
+        """Return all known tenant IDs."""
+        ...
+
+    def get_opted_in_tenant_ids(self) -> list[str]:
+        """Return tenant IDs opted in to aggregate data pooling."""
+        ...
+
+    def record_training_run(self, tenant_id: str, status: str, duration_ms: int) -> None:
+        """Record a training run audit entry for a tenant."""
+        ...
+
 
 def create_store(mode: str | None = None) -> DataStore:
     """Create the appropriate DataStore based on operating mode.

--- a/src/sigil_ml/store_postgres.py
+++ b/src/sigil_ml/store_postgres.py
@@ -34,6 +34,14 @@ class PostgresStore:
                 "Install with: pip install sigil-ml[cloud]"
             ) from None
 
+        from sigil_ml.config import validate_tenant_id
+
+        if not validate_tenant_id(tenant):
+            raise ValueError(
+                f"Invalid tenant ID '{tenant}'. "
+                "Must be 1-63 characters of lowercase alphanumeric, hyphens, or underscores."
+            )
+
         self._connection_url = connection_url
         self._tenant = tenant
         self._conn = None
@@ -291,3 +299,58 @@ class PostgresStore:
                 "VALUES (%s, %s, %s, %s, %s)",
                 (kind, endpoint, routing, latency_ms, int(time.time() * 1000)),
             )
+
+    # --- Cloud training methods ---
+
+    def get_last_training_ts(self, tenant_id: str) -> float | None:
+        """Return the last training timestamp (epoch ms) for a tenant, or None."""
+        conn = self._get_conn()
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT MAX(ts) FROM ml_events WHERE kind = 'training' AND routing = %s",
+                (tenant_id,),
+            )
+            row = cur.fetchone()
+            return float(row[0]) if row and row[0] is not None else None
+
+    def get_completed_tasks_for_tenant(self, tenant_id: str) -> list[dict]:
+        """Return completed tasks for a specific tenant."""
+        conn = self._get_conn()
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT * FROM tasks WHERE completed_at IS NOT NULL ORDER BY completed_at DESC"
+            )
+            if cur.description is None:
+                return []
+            columns = [desc[0] for desc in cur.description]
+            return [dict(zip(columns, row)) for row in cur.fetchall()]
+
+    def get_events_for_task_id(self, task_id: str) -> list[dict]:
+        """Return events associated with a specific task ID."""
+        return self.get_events_for_task(task_id)
+
+    def get_all_tenant_ids(self) -> list[str]:
+        """Return all known tenant IDs from the information schema."""
+        conn = self._get_conn()
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT schema_name FROM information_schema.schemata "
+                "WHERE schema_name NOT IN ('public', 'information_schema', 'pg_catalog', 'pg_toast')"
+            )
+            return [row[0] for row in cur.fetchall()]
+
+    def get_opted_in_tenant_ids(self) -> list[str]:
+        """Return tenant IDs opted in to aggregate data pooling.
+
+        Placeholder: returns all tenant IDs until an opt-in mechanism is implemented.
+        """
+        return self.get_all_tenant_ids()
+
+    def record_training_run(self, tenant_id: str, status: str, duration_ms: int) -> None:
+        """Record a training run audit entry for a tenant."""
+        self.insert_ml_event(
+            kind="training",
+            endpoint="cloud_trainer",
+            routing=tenant_id,
+            latency_ms=duration_ms,
+        )

--- a/src/sigil_ml/store_sqlite.py
+++ b/src/sigil_ml/store_sqlite.py
@@ -252,3 +252,29 @@ class SqliteStore:
             "VALUES (?, ?, ?, ?, ?)",
             (kind, endpoint, routing, latency_ms, int(time.time() * 1000)),
         )
+
+    # --- Cloud training methods (not supported in local SQLite mode) ---
+
+    def get_last_training_ts(self, tenant_id: str) -> float | None:
+        """Not supported in local mode."""
+        raise NotImplementedError("get_last_training_ts is a cloud-only method")
+
+    def get_completed_tasks_for_tenant(self, tenant_id: str) -> list[dict]:
+        """Not supported in local mode."""
+        raise NotImplementedError("get_completed_tasks_for_tenant is a cloud-only method")
+
+    def get_events_for_task_id(self, task_id: str) -> list[dict]:
+        """Not supported in local mode."""
+        raise NotImplementedError("get_events_for_task_id is a cloud-only method")
+
+    def get_all_tenant_ids(self) -> list[str]:
+        """Not supported in local mode."""
+        raise NotImplementedError("get_all_tenant_ids is a cloud-only method")
+
+    def get_opted_in_tenant_ids(self) -> list[str]:
+        """Not supported in local mode."""
+        raise NotImplementedError("get_opted_in_tenant_ids is a cloud-only method")
+
+    def record_training_run(self, tenant_id: str, status: str, duration_ms: int) -> None:
+        """Not supported in local mode."""
+        raise NotImplementedError("record_training_run is a cloud-only method")

--- a/src/sigil_ml/tenant.py
+++ b/src/sigil_ml/tenant.py
@@ -1,0 +1,75 @@
+"""Tenant context extraction for multi-tenant cloud serving."""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from fastapi import HTTPException, Request
+
+if TYPE_CHECKING:
+    from sigil_ml.app import AppState
+
+logger = logging.getLogger(__name__)
+
+# Sentinel for local mode -- not used for model routing.
+LOCAL_TENANT_ID = "local"
+
+
+@dataclass(frozen=True)
+class TenantContext:
+    """Per-request tenant context extracted from the authenticated request.
+
+    In cloud mode, populated from the X-Tenant-ID header (or configured header).
+    In local mode, returns a sentinel with tenant_id="local".
+    """
+
+    tenant_id: str
+    tier: str = "default"
+
+    @property
+    def is_local(self) -> bool:
+        """True when running in local mode (no real tenancy)."""
+        return self.tenant_id == LOCAL_TENANT_ID
+
+
+def tenant_header_name() -> str:
+    """Return the configured tenant header name."""
+    return os.environ.get("SIGIL_TENANT_HEADER", "X-Tenant-ID")
+
+
+def make_tenant_dependency(state: AppState):
+    """Create a FastAPI dependency that extracts tenant context.
+
+    Uses a closure to capture the application state so the dependency
+    can check the serving mode.
+
+    Args:
+        state: Application state containing the serving mode.
+
+    Returns:
+        An async callable suitable for FastAPI Depends().
+    """
+    from sigil_ml.config import ServingMode
+
+    async def get_tenant_context(request: Request) -> TenantContext:
+        """Extract tenant context from the request.
+
+        In cloud mode: reads X-Tenant-ID header, returns 401 if missing.
+        In local mode: returns sentinel context without checking headers.
+        """
+        if state.mode == ServingMode.LOCAL:
+            return TenantContext(tenant_id=LOCAL_TENANT_ID, tier="local")
+
+        header = tenant_header_name()
+        tenant_id = request.headers.get(header)
+        if not tenant_id or not tenant_id.strip():
+            raise HTTPException(
+                status_code=401,
+                detail=f"Missing required header '{header}' for cloud mode.",
+            )
+        return TenantContext(tenant_id=tenant_id.strip())
+
+    return get_tenant_context

--- a/src/sigil_ml/tenant.py
+++ b/src/sigil_ml/tenant.py
@@ -70,6 +70,18 @@ def make_tenant_dependency(state: AppState):
                 status_code=401,
                 detail=f"Missing required header '{header}' for cloud mode.",
             )
-        return TenantContext(tenant_id=tenant_id.strip())
+        tenant_id = tenant_id.strip()
+
+        from sigil_ml.config import validate_tenant_id
+
+        if not validate_tenant_id(tenant_id):
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"Invalid tenant ID '{tenant_id}'. "
+                    "Must be 1-63 characters of lowercase alphanumeric, hyphens, or underscores."
+                ),
+            )
+        return TenantContext(tenant_id=tenant_id)
 
     return get_tenant_context

--- a/src/sigil_ml/training/cloud_trainer.py
+++ b/src/sigil_ml/training/cloud_trainer.py
@@ -188,10 +188,7 @@ class CloudTrainer:
         # Stuck predictor -- synthetic
         try:
             X_stuck, y_stuck = generate_stuck_data(500)
-            stuck = StuckPredictor.__new__(StuckPredictor)
-            stuck._store = self.model_store
-            stuck.model = None
-            stuck._trained = False
+            stuck = StuckPredictor(model_store=self.model_store)
             stuck.train(X_stuck, y_stuck)
             self._save_model_to_store("stuck", stuck, tenant_id)
             models_trained.append("stuck")
@@ -205,10 +202,7 @@ class CloudTrainer:
         # Duration estimator -- synthetic
         try:
             X_dur, y_dur = generate_duration_data(500)
-            duration = DurationEstimator.__new__(DurationEstimator)
-            duration._store = self.model_store
-            duration.model = None
-            duration._trained = False
+            duration = DurationEstimator(model_store=self.model_store)
             duration.train(X_dur, y_dur)
             self._save_model_to_store("duration", duration, tenant_id)
             models_trained.append("duration")
@@ -255,12 +249,9 @@ class CloudTrainer:
             if X_stuck_list:
                 X_stuck = np.array(X_stuck_list)
                 y_stuck = np.array(y_stuck_list)
-                stuck_model = StuckPredictor.__new__(StuckPredictor)
-                stuck_model._store = self.model_store
-                stuck_model.model = None
-                stuck_model._trained = False
-                stuck_model.train(X_stuck, y_stuck)
-                self._save_model_to_store("stuck", stuck_model, tenant_id)
+                stuck_predictor = StuckPredictor(model_store=self.model_store)
+                stuck_predictor.train(X_stuck, y_stuck)
+                self._save_model_to_store("stuck", stuck_predictor, tenant_id)
                 models_trained.append("stuck")
         except Exception:
             logger.warning(
@@ -290,12 +281,9 @@ class CloudTrainer:
             if X_dur_list:
                 X_dur = np.array(X_dur_list)
                 y_dur = np.array(y_dur_list)
-                dur_model = DurationEstimator.__new__(DurationEstimator)
-                dur_model._store = self.model_store
-                dur_model.model = None
-                dur_model._trained = False
-                dur_model.train(X_dur, y_dur)
-                self._save_model_to_store("duration", dur_model, tenant_id)
+                dur_estimator = DurationEstimator(model_store=self.model_store)
+                dur_estimator.train(X_dur, y_dur)
+                self._save_model_to_store("duration", dur_estimator, tenant_id)
                 models_trained.append("duration")
         except Exception:
             logger.warning(
@@ -611,44 +599,19 @@ class CloudTrainer:
                 exc_info=True,
             )
 
-    def _get_last_training_ts(self, tenant_id: str) -> int | None:
+    def _get_last_training_ts(self, tenant_id: str) -> float | None:
         """Get the last training timestamp for a tenant.
 
         Returns epoch milliseconds, or None if never trained.
-        Delegates to DataStore if it supports the method; returns None otherwise.
         """
-        try:
-            return self.data_store.get_last_training_ts(tenant_id)  # type: ignore[attr-defined]
-        except AttributeError:
-            # DataStore doesn't have this method -- assume never trained
-            return None
+        return self.data_store.get_last_training_ts(tenant_id)
 
     def _query_completed_tasks(self, tenant_id: str) -> list[dict]:
-        """Query completed tasks for a tenant.
-
-        Adapts to whatever completed-task query the DataStore supports.
-        """
-        try:
-            return self.data_store.query_completed_tasks(tenant_id)  # type: ignore[attr-defined]
-        except AttributeError:
-            # Fallback: use existing DataStore methods
-            task_ids = self.data_store.get_completed_task_ids()
-            tasks = []
-            for tid in task_ids:
-                task = self.data_store.get_task_by_id(tid)
-                if task is not None:
-                    tasks.append(task)
-            return tasks
+        """Query completed tasks for a tenant via the DataStore protocol."""
+        return self.data_store.get_completed_tasks_for_tenant(tenant_id)
 
     def _query_events_for_task(
         self, tenant_id: str, task_id: str
     ) -> list[dict]:
-        """Query events for a specific task.
-
-        Adapts to whatever event query the DataStore supports.
-        """
-        try:
-            return self.data_store.query_events_for_task(tenant_id, task_id)  # type: ignore[attr-defined]
-        except AttributeError:
-            # Fallback: use existing DataStore method
-            return self.data_store.get_events_for_task(task_id)
+        """Query events for a specific task via the DataStore protocol."""
+        return self.data_store.get_events_for_task_id(task_id)

--- a/src/sigil_ml/training/cloud_trainer.py
+++ b/src/sigil_ml/training/cloud_trainer.py
@@ -1,0 +1,654 @@
+"""Cloud training orchestrator using DataStore and ModelStore abstractions.
+
+Supports per-tenant, batch (all-tenants), and aggregate training modes.
+Does NOT subclass or modify the local Trainer -- it is a parallel
+implementation that reuses model classes' .train() methods directly.
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+import random
+import time
+from datetime import datetime, timezone
+from typing import Any
+
+import joblib
+import numpy as np
+
+from sigil_ml.features import (
+    extract_duration_features_from_data,
+    extract_stuck_features_from_data,
+)
+from sigil_ml.models.duration import FEATURE_NAMES as DURATION_FEATURES
+from sigil_ml.models.duration import DurationEstimator
+from sigil_ml.models.stuck import FEATURE_NAMES as STUCK_FEATURES
+from sigil_ml.models.stuck import StuckPredictor
+from sigil_ml.storage.model_store import ModelStore
+from sigil_ml.store import DataStore
+from sigil_ml.training.models import (
+    CloudTrainingConfig,
+    TrainingBatch,
+    TrainingRun,
+)
+from sigil_ml.training.synthetic import generate_duration_data, generate_stuck_data
+
+logger = logging.getLogger(__name__)
+
+AGGREGATE_TENANT_ID = "__aggregate__"
+
+
+class CloudTrainer:
+    """Orchestrates model training for cloud deployments.
+
+    Uses DataStore for reading training data and ModelStore for
+    persisting trained model weights. Supports per-tenant, batch,
+    and aggregate training modes.
+    """
+
+    def __init__(
+        self,
+        data_store: DataStore,
+        model_store: ModelStore,
+        config: CloudTrainingConfig | None = None,
+        training_lock: Any | None = None,
+    ) -> None:
+        self.data_store = data_store
+        self.model_store = model_store
+        self.config = config or CloudTrainingConfig()
+        self.training_lock = training_lock
+
+    # ------------------------------------------------------------------
+    # Per-tenant training (WP02)
+    # ------------------------------------------------------------------
+
+    def train_tenant(self, tenant_id: str) -> TrainingRun:
+        """Train all models for a single tenant.
+
+        Flow: lock -> interval check -> threshold check -> train -> save -> audit.
+        """
+        start = time.time()
+        started_at = datetime.now(timezone.utc)
+
+        # Lock check (if configured) -- before ANY other operation (WP04)
+        if self.training_lock is not None:
+            if not self.training_lock.acquire(tenant_id):
+                return TrainingRun(
+                    tenant_id=tenant_id,
+                    status="skipped_locked",
+                    duration_ms=int((time.time() - start) * 1000),
+                    started_at=started_at,
+                    completed_at=datetime.now(timezone.utc),
+                )
+
+        try:
+            return self._train_tenant_inner(tenant_id, start, started_at)
+        except Exception as e:
+            elapsed = time.time() - start
+            logger.error(
+                "Training failed for tenant %s: %s",
+                tenant_id,
+                e,
+                exc_info=True,
+            )
+            run = TrainingRun(
+                tenant_id=tenant_id,
+                status="failed",
+                error=str(e)[:500],
+                duration_ms=int(elapsed * 1000),
+                started_at=started_at,
+                completed_at=datetime.now(timezone.utc),
+            )
+            self._record_audit_event(tenant_id, run)
+            return run
+        finally:
+            if self.training_lock is not None:
+                self.training_lock.release(tenant_id)
+
+    def _train_tenant_inner(
+        self, tenant_id: str, start: float, started_at: datetime
+    ) -> TrainingRun:
+        """Core per-tenant training logic (interval, threshold, train, audit)."""
+        # 1. Interval check (cheapest -- avoids all data queries if too recent)
+        last_ts = self._get_last_training_ts(tenant_id)
+        if last_ts is not None:
+            elapsed_sec = time.time() - (last_ts / 1000.0)
+            if elapsed_sec < self.config.min_interval_sec:
+                logger.info(
+                    "Skipping tenant %s: trained %d sec ago (interval: %d sec)",
+                    tenant_id,
+                    int(elapsed_sec),
+                    self.config.min_interval_sec,
+                )
+                run = TrainingRun(
+                    tenant_id=tenant_id,
+                    status="skipped",
+                    duration_ms=int((time.time() - start) * 1000),
+                    started_at=started_at,
+                    completed_at=datetime.now(timezone.utc),
+                )
+                self._record_audit_event(tenant_id, run)
+                return run
+
+        # 2. Data threshold check
+        tasks = self._query_completed_tasks(tenant_id)
+        has_sufficient_data = len(tasks) >= self.config.min_tasks
+
+        # 3. Synthetic fallback if insufficient data
+        if not has_sufficient_data:
+            logger.info(
+                "Tenant %s has %d tasks (< %d), using synthetic data",
+                tenant_id,
+                len(tasks),
+                self.config.min_tasks,
+            )
+            models_trained = self._train_synthetic(tenant_id)
+            elapsed_ms = int((time.time() - start) * 1000)
+            run = TrainingRun(
+                tenant_id=tenant_id,
+                status="trained",
+                sample_count=500,
+                models_trained=models_trained,
+                duration_ms=elapsed_ms,
+                started_at=started_at,
+                completed_at=datetime.now(timezone.utc),
+            )
+            self._record_audit_event(tenant_id, run)
+            return run
+
+        # 4. Real data: extract features and build task_events map
+        task_events: dict[str, list[dict]] = {}
+        for task in tasks:
+            events = self._query_events_for_task(tenant_id, task["id"])
+            task_events[task["id"]] = events
+
+        # 5. Train all models from real data
+        models_trained = self._train_models_from_tasks(
+            tasks, task_events, tenant_id
+        )
+
+        elapsed_ms = int((time.time() - start) * 1000)
+        run = TrainingRun(
+            tenant_id=tenant_id,
+            status="trained",
+            sample_count=len(tasks),
+            models_trained=models_trained,
+            duration_ms=elapsed_ms,
+            started_at=started_at,
+            completed_at=datetime.now(timezone.utc),
+        )
+        self._record_audit_event(tenant_id, run)
+        return run
+
+    def _train_synthetic(self, tenant_id: str) -> list[str]:
+        """Train stuck and duration models with synthetic data (cold-start)."""
+        models_trained: list[str] = []
+
+        # Stuck predictor -- synthetic
+        try:
+            X_stuck, y_stuck = generate_stuck_data(500)
+            stuck = StuckPredictor.__new__(StuckPredictor)
+            stuck._store = self.model_store
+            stuck.model = None
+            stuck._trained = False
+            stuck.train(X_stuck, y_stuck)
+            self._save_model_to_store("stuck", stuck, tenant_id)
+            models_trained.append("stuck")
+        except Exception:
+            logger.warning(
+                "Failed to train synthetic stuck model for tenant %s",
+                tenant_id,
+                exc_info=True,
+            )
+
+        # Duration estimator -- synthetic
+        try:
+            X_dur, y_dur = generate_duration_data(500)
+            duration = DurationEstimator.__new__(DurationEstimator)
+            duration._store = self.model_store
+            duration.model = None
+            duration._trained = False
+            duration.train(X_dur, y_dur)
+            self._save_model_to_store("duration", duration, tenant_id)
+            models_trained.append("duration")
+        except Exception:
+            logger.warning(
+                "Failed to train synthetic duration model for tenant %s",
+                tenant_id,
+                exc_info=True,
+            )
+
+        return models_trained
+
+    def _train_models_from_tasks(
+        self,
+        tasks: list[dict],
+        task_events: dict[str, list[dict]],
+        tenant_id: str,
+    ) -> list[str]:
+        """Train all model types from provided tasks and events.
+
+        Shared by train_tenant() (single-tenant) and train_aggregate() (pooled).
+
+        Returns:
+            List of model names that were successfully trained.
+        """
+        models_trained: list[str] = []
+
+        # --- Stuck predictor ---
+        try:
+            X_stuck_list: list[list[float]] = []
+            y_stuck_list: list[float] = []
+            for task in tasks:
+                events = task_events.get(task["id"], [])
+                feats = extract_stuck_features_from_data(task, events)
+                x = [feats.get(f, 0.0) for f in STUCK_FEATURES]
+                X_stuck_list.append(x)
+                # Heuristic label: stuck if high test failures AND long time in phase
+                stuck = (
+                    feats["test_failure_count"] > 3
+                    and feats["time_in_phase_sec"] > 600
+                )
+                y_stuck_list.append(1.0 if stuck else 0.0)
+
+            if X_stuck_list:
+                X_stuck = np.array(X_stuck_list)
+                y_stuck = np.array(y_stuck_list)
+                stuck_model = StuckPredictor.__new__(StuckPredictor)
+                stuck_model._store = self.model_store
+                stuck_model.model = None
+                stuck_model._trained = False
+                stuck_model.train(X_stuck, y_stuck)
+                self._save_model_to_store("stuck", stuck_model, tenant_id)
+                models_trained.append("stuck")
+        except Exception:
+            logger.warning(
+                "Failed to train stuck model for tenant %s",
+                tenant_id,
+                exc_info=True,
+            )
+
+        # --- Duration estimator ---
+        try:
+            X_dur_list: list[list[float]] = []
+            y_dur_list: list[float] = []
+            for task in tasks:
+                events = task_events.get(task["id"], [])
+                feats = extract_duration_features_from_data(task, events)
+                x = [feats.get(f, 0.0) for f in DURATION_FEATURES]
+                X_dur_list.append(x)
+                # Duration label: (completed_at - started_at) in minutes, min 1.0
+                started = task.get("started_at", 0)
+                completed = task.get("completed_at", 0)
+                if started and completed:
+                    duration_min = (completed - started) / 60000.0
+                    y_dur_list.append(max(duration_min, 1.0))
+                else:
+                    y_dur_list.append(60.0)  # default 60 min if timestamps missing
+
+            if X_dur_list:
+                X_dur = np.array(X_dur_list)
+                y_dur = np.array(y_dur_list)
+                dur_model = DurationEstimator.__new__(DurationEstimator)
+                dur_model._store = self.model_store
+                dur_model.model = None
+                dur_model._trained = False
+                dur_model.train(X_dur, y_dur)
+                self._save_model_to_store("duration", dur_model, tenant_id)
+                models_trained.append("duration")
+        except Exception:
+            logger.warning(
+                "Failed to train duration model for tenant %s",
+                tenant_id,
+                exc_info=True,
+            )
+
+        # --- Activity classifier ---
+        # Rule-based by default (no ML training needed for cold-start).
+        # ActivityClassifier uses heuristic classification without trained weights.
+        # Skip training; default rules apply.
+
+        # --- Workflow state predictor ---
+        # Also rule-based by default. Skip training; default rules apply.
+
+        # --- Quality estimator ---
+        # Uses weight-based scoring. Skip training; default weights apply.
+
+        return models_trained
+
+    # ------------------------------------------------------------------
+    # Batch training (WP03)
+    # ------------------------------------------------------------------
+
+    def train_all_tenants(self) -> TrainingBatch:
+        """Discover and train all eligible tenants in batch.
+
+        Each tenant is trained independently. Failures for individual
+        tenants do not interrupt the batch (FR-007).
+
+        Returns:
+            TrainingBatch with per-tenant TrainingRun results.
+        """
+        start = time.time()
+        tenants = self._discover_tenants()
+
+        batch = TrainingBatch(
+            started_at=datetime.now(timezone.utc),
+        )
+
+        for i, tenant_id in enumerate(tenants, 1):
+            logger.info(
+                "Processing tenant %d/%d: %s", i, len(tenants), tenant_id
+            )
+            run = self._train_tenant_safe(tenant_id)
+            batch.runs.append(run)
+
+        batch.total_duration_ms = int((time.time() - start) * 1000)
+        batch.completed_at = datetime.now(timezone.utc)
+
+        logger.info(
+            "Batch complete: %d trained, %d skipped, %d failed (of %d total) in %dms",
+            batch.trained,
+            batch.skipped,
+            batch.failed,
+            batch.total,
+            batch.total_duration_ms,
+        )
+
+        # Record batch-level audit event (WP06)
+        try:
+            self.data_store.insert_ml_event(
+                kind="batch_training",
+                endpoint="cloud_trainer",
+                routing="__batch__",
+                latency_ms=batch.total_duration_ms,
+            )
+            self.data_store.commit()
+        except Exception:
+            logger.warning("Failed to record batch audit event", exc_info=True)
+
+        return batch
+
+    def _train_tenant_safe(self, tenant_id: str) -> TrainingRun:
+        """Train a tenant with full error isolation.
+
+        Catches all exceptions, logs them, and returns a failed TrainingRun
+        instead of propagating the error.
+        """
+        try:
+            return self.train_tenant(tenant_id)
+        except Exception as e:
+            logger.error(
+                "Training failed for tenant %s: %s",
+                tenant_id,
+                str(e),
+                exc_info=True,
+            )
+            error_msg = str(e)[:500] if len(str(e)) > 500 else str(e)
+            return TrainingRun(
+                tenant_id=tenant_id,
+                status="failed",
+                error=error_msg,
+            )
+
+    def _discover_tenants(self) -> list[str]:
+        """Discover all tenants with synced data."""
+        from sigil_ml.training.tenant_discovery import discover_eligible_tenants
+
+        return discover_eligible_tenants(self.data_store)
+
+    # ------------------------------------------------------------------
+    # Aggregate training (WP05)
+    # ------------------------------------------------------------------
+
+    def train_aggregate(self) -> TrainingRun:
+        """Train aggregate models from pooled opted-in tenant data.
+
+        Returns a TrainingRun with tenant_id="__aggregate__".
+        """
+        start = time.time()
+        started_at = datetime.now(timezone.utc)
+
+        try:
+            return self._train_aggregate_inner(start, started_at)
+        except Exception as e:
+            elapsed = time.time() - start
+            logger.error("Aggregate training failed: %s", e, exc_info=True)
+            run = TrainingRun(
+                tenant_id=AGGREGATE_TENANT_ID,
+                status="failed",
+                error=str(e)[:500],
+                duration_ms=int(elapsed * 1000),
+                started_at=started_at,
+                completed_at=datetime.now(timezone.utc),
+            )
+            self._record_audit_event(AGGREGATE_TENANT_ID, run)
+            return run
+
+    def _train_aggregate_inner(
+        self, start: float, started_at: datetime
+    ) -> TrainingRun:
+        """Core aggregate training logic."""
+        # 1. Discover opted-in tenants
+        tenant_ids = self._discover_opted_in_tenants()
+
+        # 2. Minimum opt-in threshold warning (T028)
+        warning_msg: str | None = None
+        if len(tenant_ids) < self.config.aggregate_min_tenants:
+            warning_msg = (
+                f"Only {len(tenant_ids)} opted-in tenants "
+                f"(recommended minimum: {self.config.aggregate_min_tenants}). "
+                f"Aggregate model may be unreliable."
+            )
+            logger.warning(warning_msg)
+
+        if not tenant_ids:
+            run = TrainingRun(
+                tenant_id=AGGREGATE_TENANT_ID,
+                status="skipped",
+                error="No opted-in tenants found",
+                duration_ms=int((time.time() - start) * 1000),
+                started_at=started_at,
+                completed_at=datetime.now(timezone.utc),
+            )
+            self._record_audit_event(AGGREGATE_TENANT_ID, run)
+            return run
+
+        # 3. Pool data from all opted-in tenants
+        all_tasks, task_events, tenant_counts = self._pool_training_data(
+            tenant_ids
+        )
+
+        # 4. Apply sampling strategy
+        sampled_tasks = self._sample_pooled_data(all_tasks, tenant_counts)
+        total_samples = len(sampled_tasks)
+
+        if total_samples == 0:
+            run = TrainingRun(
+                tenant_id=AGGREGATE_TENANT_ID,
+                status="skipped",
+                error="No tasks found across opted-in tenants",
+                duration_ms=int((time.time() - start) * 1000),
+                started_at=started_at,
+                completed_at=datetime.now(timezone.utc),
+            )
+            self._record_audit_event(AGGREGATE_TENANT_ID, run)
+            return run
+
+        # 5. Extract features and train all models
+        models_trained = self._train_models_from_tasks(
+            sampled_tasks,
+            task_events,
+            tenant_id=AGGREGATE_TENANT_ID,
+        )
+
+        # 6. Build result
+        elapsed_ms = int((time.time() - start) * 1000)
+        run = TrainingRun(
+            tenant_id=AGGREGATE_TENANT_ID,
+            status="trained",
+            sample_count=total_samples,
+            models_trained=models_trained,
+            duration_ms=elapsed_ms,
+            error=warning_msg,  # Non-fatal warning included in output
+            started_at=started_at,
+            completed_at=datetime.now(timezone.utc),
+        )
+        self._record_audit_event(AGGREGATE_TENANT_ID, run)
+        return run
+
+    def _discover_opted_in_tenants(self) -> list[str]:
+        """Discover tenants opted in to aggregate data pooling."""
+        from sigil_ml.training.tenant_discovery import discover_opted_in_tenants
+
+        return discover_opted_in_tenants(self.data_store)
+
+    def _pool_training_data(
+        self, tenant_ids: list[str]
+    ) -> tuple[list[dict], dict[str, list[dict]], dict[str, int]]:
+        """Pool training data from multiple opted-in tenants.
+
+        Returns:
+            (all_tasks, task_events, tenant_task_counts)
+            - all_tasks: list of task dicts, each tagged with _tenant_id
+            - task_events: dict mapping task_id -> list of event dicts
+            - tenant_task_counts: dict mapping tenant_id -> task count
+        """
+        all_tasks: list[dict] = []
+        task_events: dict[str, list[dict]] = {}
+        tenant_counts: dict[str, int] = {}
+
+        for tenant_id in tenant_ids:
+            tasks = self._query_completed_tasks(tenant_id)
+            tenant_counts[tenant_id] = len(tasks)
+
+            for task in tasks:
+                task["_tenant_id"] = tenant_id  # Tag with source tenant
+                events = self._query_events_for_task(tenant_id, task["id"])
+                all_tasks.append(task)
+                task_events[task["id"]] = events
+
+        logger.info(
+            "Pooled %d total tasks from %d tenants (before sampling)",
+            len(all_tasks),
+            len(tenant_ids),
+        )
+        return all_tasks, task_events, tenant_counts
+
+    def _sample_pooled_data(
+        self,
+        all_tasks: list[dict],
+        tenant_counts: dict[str, int],
+    ) -> list[dict]:
+        """Apply per-tenant sampling caps to pooled data.
+
+        Each tenant contributes at most max_tasks_per_tenant tasks.
+        Sampling is deterministic (seeded RNG) for reproducibility.
+
+        Returns:
+            Sampled task list.
+        """
+        max_per = self.config.max_tasks_per_tenant
+        rng = random.Random(42)  # deterministic for reproducibility
+
+        sampled: list[dict] = []
+        for tenant_id in tenant_counts:
+            tenant_tasks = [
+                t for t in all_tasks if t.get("_tenant_id") == tenant_id
+            ]
+
+            if len(tenant_tasks) > max_per:
+                logger.info(
+                    "Sampling %d/%d tasks from tenant %s (cap: %d)",
+                    max_per,
+                    len(tenant_tasks),
+                    tenant_id,
+                    max_per,
+                )
+                tenant_tasks = rng.sample(tenant_tasks, max_per)
+
+            sampled.extend(tenant_tasks)
+
+        logger.info(
+            "Aggregate dataset after sampling: %d tasks from %d tenants",
+            len(sampled),
+            len(tenant_counts),
+        )
+        return sampled
+
+    # ------------------------------------------------------------------
+    # Helper methods
+    # ------------------------------------------------------------------
+
+    def _save_model_to_store(
+        self, model_name: str, model: Any, tenant_id: str
+    ) -> None:
+        """Serialize a trained model and save via ModelStore with tenant prefix."""
+        buf = io.BytesIO()
+        joblib.dump(model.model, buf)
+        # Save with tenant-scoped key: {tenant_id}/{model_name}
+        scoped_name = f"{tenant_id}/{model_name}"
+        self.model_store.save(scoped_name, buf.getvalue())
+
+    def _record_audit_event(self, tenant_id: str, run: TrainingRun) -> None:
+        """Record a training audit event via DataStore."""
+        try:
+            kind = "training"
+            if tenant_id == AGGREGATE_TENANT_ID:
+                kind = "aggregate_training"
+            self.data_store.insert_ml_event(
+                kind=kind,
+                endpoint="cloud_trainer",
+                routing=tenant_id,
+                latency_ms=run.duration_ms,
+            )
+            self.data_store.commit()
+        except Exception:
+            logger.warning(
+                "Failed to record training event for tenant %s",
+                tenant_id,
+                exc_info=True,
+            )
+
+    def _get_last_training_ts(self, tenant_id: str) -> int | None:
+        """Get the last training timestamp for a tenant.
+
+        Returns epoch milliseconds, or None if never trained.
+        Delegates to DataStore if it supports the method; returns None otherwise.
+        """
+        try:
+            return self.data_store.get_last_training_ts(tenant_id)  # type: ignore[attr-defined]
+        except AttributeError:
+            # DataStore doesn't have this method -- assume never trained
+            return None
+
+    def _query_completed_tasks(self, tenant_id: str) -> list[dict]:
+        """Query completed tasks for a tenant.
+
+        Adapts to whatever completed-task query the DataStore supports.
+        """
+        try:
+            return self.data_store.query_completed_tasks(tenant_id)  # type: ignore[attr-defined]
+        except AttributeError:
+            # Fallback: use existing DataStore methods
+            task_ids = self.data_store.get_completed_task_ids()
+            tasks = []
+            for tid in task_ids:
+                task = self.data_store.get_task_by_id(tid)
+                if task is not None:
+                    tasks.append(task)
+            return tasks
+
+    def _query_events_for_task(
+        self, tenant_id: str, task_id: str
+    ) -> list[dict]:
+        """Query events for a specific task.
+
+        Adapts to whatever event query the DataStore supports.
+        """
+        try:
+            return self.data_store.query_events_for_task(tenant_id, task_id)  # type: ignore[attr-defined]
+        except AttributeError:
+            # Fallback: use existing DataStore method
+            return self.data_store.get_events_for_task(task_id)

--- a/src/sigil_ml/training/locking.py
+++ b/src/sigil_ml/training/locking.py
@@ -1,0 +1,115 @@
+"""Training lock protocol and implementations for preventing concurrent training."""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from sigil_ml.store import DataStore
+
+logger = logging.getLogger(__name__)
+
+# Default stale lock timeout: 2 hours (configurable via env var)
+STALE_LOCK_TIMEOUT_SEC = int(os.environ.get("SIGIL_ML_LOCK_TIMEOUT_SEC", "7200"))
+
+
+@runtime_checkable
+class TrainingLock(Protocol):
+    """Protocol for distributed training locks.
+
+    Prevents concurrent training for the same tenant across
+    multiple processes/pods. Implementations must be safe for
+    use from multiple K8s pods accessing the same database.
+    """
+
+    def acquire(self, tenant_id: str) -> bool:
+        """Attempt to acquire a training lock for the given tenant.
+
+        Returns:
+            True if the lock was acquired (caller proceeds with training).
+            False if another process holds a fresh lock (caller should skip).
+        """
+        ...
+
+    def release(self, tenant_id: str) -> None:
+        """Release the training lock for the given tenant.
+
+        No-op if the lock is not held by this process.
+        """
+        ...
+
+
+class DataStoreTrainingLock:
+    """Training lock backed by a database table via DataStore.
+
+    Uses an ml_training_locks table:
+      - tenant_id TEXT PRIMARY KEY
+      - acquired_at BIGINT NOT NULL (epoch milliseconds)
+      - pid TEXT NOT NULL (process ID of lock holder)
+
+    Acquire logic (atomic):
+      1. Try INSERT -- if succeeds, lock acquired
+      2. If conflict (lock exists):
+         a. If lock.acquired_at + stale_timeout < now -> override (stale)
+         b. If fresh -> return False (lock held)
+
+    The DataStore must support:
+      - acquire_training_lock(tenant_id, pid, stale_timeout_sec) -> bool
+      - release_training_lock(tenant_id) -> None
+    """
+
+    def __init__(
+        self,
+        data_store: DataStore,
+        stale_timeout_sec: int = STALE_LOCK_TIMEOUT_SEC,
+    ) -> None:
+        self.data_store = data_store
+        self.stale_timeout_sec = stale_timeout_sec
+        self._pid = str(os.getpid())
+
+    def acquire(self, tenant_id: str) -> bool:
+        """Attempt to acquire the lock.
+
+        Handles stale lock detection: if the existing lock is older
+        than stale_timeout_sec, it is overridden with a warning.
+        """
+        try:
+            acquired = self.data_store.acquire_training_lock(
+                tenant_id=tenant_id,
+                pid=self._pid,
+                stale_timeout_sec=self.stale_timeout_sec,
+            )
+        except AttributeError:
+            # DataStore doesn't support locking -- treat as acquired
+            logger.debug(
+                "DataStore does not support training locks, proceeding without lock"
+            )
+            return True
+
+        if acquired:
+            logger.debug(
+                "Acquired training lock for tenant %s (pid=%s)",
+                tenant_id,
+                self._pid,
+            )
+        else:
+            logger.info("Training lock held for tenant %s, skipping", tenant_id)
+        return acquired
+
+    def release(self, tenant_id: str) -> None:
+        """Release the lock. No-op if not held."""
+        try:
+            self.data_store.release_training_lock(tenant_id)
+            logger.debug("Released training lock for tenant %s", tenant_id)
+        except AttributeError:
+            # DataStore doesn't support locking -- no-op
+            pass
+        except Exception:
+            logger.warning(
+                "Failed to release lock for tenant %s",
+                tenant_id,
+                exc_info=True,
+            )

--- a/src/sigil_ml/training/locking.py
+++ b/src/sigil_ml/training/locking.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import logging
 import os
-import time
 from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
 if TYPE_CHECKING:

--- a/src/sigil_ml/training/models.py
+++ b/src/sigil_ml/training/models.py
@@ -1,0 +1,152 @@
+"""Data models for the cloud training pipeline."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any
+
+# Valid TrainingRun statuses
+STATUS_TRAINED = "trained"
+STATUS_SKIPPED = "skipped"
+STATUS_SKIPPED_LOCKED = "skipped_locked"
+STATUS_FAILED = "failed"
+
+
+@dataclass
+class CloudTrainingConfig:
+    """Configuration for cloud training runs."""
+
+    min_interval_sec: int = 3600
+    min_tasks: int = 10
+    max_tasks_per_tenant: int = 1000
+    aggregate_min_tenants: int = 3
+
+
+@dataclass
+class TrainingRun:
+    """Result of training models for a single tenant or aggregate pool."""
+
+    tenant_id: str
+    status: str  # "trained", "failed", "skipped", "skipped_locked"
+    models_trained: list[str] = field(default_factory=list)
+    sample_count: int = 0
+    duration_ms: int = 0
+    error: str | None = None
+    started_at: datetime | None = None
+    completed_at: datetime | None = None
+    data_freshness_sec: float | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a JSON-compatible dictionary."""
+        d: dict[str, Any] = {
+            "tenant_id": self.tenant_id,
+            "status": self.status,
+            "models_trained": self.models_trained,
+            "sample_count": self.sample_count,
+            "duration_ms": self.duration_ms,
+        }
+        if self.error is not None:
+            d["error"] = self.error
+        if self.started_at is not None:
+            d["started_at"] = self.started_at.isoformat()
+        if self.completed_at is not None:
+            d["completed_at"] = self.completed_at.isoformat()
+        if self.data_freshness_sec is not None:
+            d["data_freshness_sec"] = self.data_freshness_sec
+        return d
+
+    def to_json(self, indent: int | None = 2) -> str:
+        """Serialize to a JSON string."""
+        return json.dumps(self.to_dict(), indent=indent)
+
+
+@dataclass
+class TrainingBatch:
+    """Aggregated result of batch training across multiple tenants."""
+
+    runs: list[TrainingRun] = field(default_factory=list)
+    total_duration_ms: int = 0
+    started_at: datetime | None = None
+    completed_at: datetime | None = None
+
+    @property
+    def trained(self) -> int:
+        """Count of successfully trained runs."""
+        return sum(1 for r in self.runs if r.status == STATUS_TRAINED)
+
+    @property
+    def skipped(self) -> int:
+        """Count of skipped runs (including skipped_locked)."""
+        return sum(1 for r in self.runs if r.status.startswith("skipped"))
+
+    @property
+    def failed(self) -> int:
+        """Count of failed runs."""
+        return sum(1 for r in self.runs if r.status == STATUS_FAILED)
+
+    @property
+    def total(self) -> int:
+        """Total number of runs."""
+        return len(self.runs)
+
+    @property
+    def status_breakdown(self) -> dict[str, int]:
+        """Count runs by status for monitoring."""
+        counts: dict[str, int] = {}
+        for run in self.runs:
+            counts[run.status] = counts.get(run.status, 0) + 1
+        return counts
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a JSON-compatible dictionary."""
+        d: dict[str, Any] = {
+            "total": self.total,
+            "trained": self.trained,
+            "skipped": self.skipped,
+            "failed": self.failed,
+            "status_breakdown": self.status_breakdown,
+            "total_duration_ms": self.total_duration_ms,
+            "runs": [r.to_dict() for r in self.runs],
+        }
+        if self.started_at is not None:
+            d["started_at"] = self.started_at.isoformat()
+        if self.completed_at is not None:
+            d["completed_at"] = self.completed_at.isoformat()
+        return d
+
+    def to_json(self, indent: int | None = 2) -> str:
+        """Serialize to a JSON string."""
+        return json.dumps(self.to_dict(), indent=indent)
+
+
+@dataclass
+class TrainingSummary:
+    """Human-readable summary for CLI output."""
+
+    mode: str  # "single", "batch", "aggregate"
+    total_tenants: int = 0
+    trained: int = 0
+    skipped: int = 0
+    failed: int = 0
+    total_samples: int = 0
+    total_duration_ms: int = 0
+    per_tenant: list[dict] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a JSON-compatible dictionary."""
+        return {
+            "mode": self.mode,
+            "total_tenants": self.total_tenants,
+            "trained": self.trained,
+            "skipped": self.skipped,
+            "failed": self.failed,
+            "total_samples": self.total_samples,
+            "total_duration_ms": self.total_duration_ms,
+            "per_tenant": self.per_tenant,
+        }
+
+    def to_json(self, indent: int | None = 2) -> str:
+        """Serialize to a JSON string."""
+        return json.dumps(self.to_dict(), indent=indent)

--- a/src/sigil_ml/training/models.py
+++ b/src/sigil_ml/training/models.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import Any
 
 # Valid TrainingRun statuses

--- a/src/sigil_ml/training/tenant_discovery.py
+++ b/src/sigil_ml/training/tenant_discovery.py
@@ -1,0 +1,39 @@
+"""Tenant discovery for cloud training pipeline."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from sigil_ml.store import DataStore
+
+logger = logging.getLogger(__name__)
+
+
+def discover_eligible_tenants(data_store: DataStore) -> list[str]:
+    """Discover all tenant IDs with synced data.
+
+    Returns all tenant IDs from the DataStore. Eligibility filtering
+    (threshold, interval) is handled by train_tenant() for each tenant.
+
+    Returns:
+        List of tenant ID strings.
+    """
+    tenants = data_store.list_tenants()
+    logger.info("Discovered %d tenants with synced data", len(tenants))
+    return tenants
+
+
+def discover_opted_in_tenants(data_store: DataStore) -> list[str]:
+    """Discover tenants that have opted in to aggregate data pooling.
+
+    Returns only tenant IDs where data_pooling_opted_in flag is True.
+    The query is always fresh (not cached) to respect opt-out changes.
+
+    Returns:
+        List of opted-in tenant ID strings.
+    """
+    tenants = data_store.list_opted_in_tenants()
+    logger.info("Found %d opted-in tenants for aggregate training", len(tenants))
+    return tenants

--- a/tests/test_cloud_training.py
+++ b/tests/test_cloud_training.py
@@ -78,8 +78,28 @@ class MockDataStore:
     def query_completed_tasks(self, tenant_id: str) -> list[dict]:
         return list(self._tasks.get(tenant_id, []))
 
+    def get_completed_tasks_for_tenant(self, tenant_id: str) -> list[dict]:
+        return list(self._tasks.get(tenant_id, []))
+
     def query_events_for_task(self, tenant_id: str, task_id: str) -> list[dict]:
         return list(self._events.get(task_id, []))
+
+    def get_events_for_task_id(self, task_id: str) -> list[dict]:
+        return list(self._events.get(task_id, []))
+
+    def get_all_tenant_ids(self) -> list[str]:
+        return list(self._tenants)
+
+    def get_opted_in_tenant_ids(self) -> list[str]:
+        return list(self._opted_in_tenants)
+
+    def record_training_run(self, tenant_id: str, status: str, duration_ms: int) -> None:
+        self._ml_events.append({
+            "kind": "training",
+            "endpoint": "cloud_trainer",
+            "routing": tenant_id,
+            "latency_ms": duration_ms,
+        })
 
     # Existing DataStore protocol methods (fallback path)
     def get_completed_task_ids(self) -> list[str]:
@@ -476,9 +496,9 @@ class TestCloudTrainerPerTenant:
         """Errors during training return a failed TrainingRun."""
         from sigil_ml.training.cloud_trainer import CloudTrainer
 
-        # DataStore that raises on query_completed_tasks
+        # DataStore that raises on get_completed_tasks_for_tenant
         data_store = MockDataStore()
-        data_store.query_completed_tasks = MagicMock(side_effect=ValueError("boom"))
+        data_store.get_completed_tasks_for_tenant = MagicMock(side_effect=ValueError("boom"))
         model_store = MockModelStore()
         trainer = CloudTrainer(data_store, model_store)
         run = trainer.train_tenant("t1")
@@ -550,15 +570,15 @@ class TestBatchTraining:
             tasks_per_tenant={"t1": [], "t2": tasks_t2},
             events_per_task=events_t2,
         )
-        # Make t1 fail by having query_completed_tasks raise for t1
-        original_query = data_store.query_completed_tasks
+        # Make t1 fail by having get_completed_tasks_for_tenant raise for t1
+        original_query = data_store.get_completed_tasks_for_tenant
 
         def failing_query(tenant_id: str) -> list[dict]:
             if tenant_id == "t1":
                 raise ConnectionError("DB unreachable for t1")
             return original_query(tenant_id)
 
-        data_store.query_completed_tasks = failing_query  # type: ignore[assignment]
+        data_store.get_completed_tasks_for_tenant = failing_query  # type: ignore[assignment]
         model_store = MockModelStore()
         trainer = CloudTrainer(data_store, model_store)
         batch = trainer.train_all_tenants()
@@ -673,7 +693,7 @@ class TestTrainingLock:
 
         lock = MockTrainingLock()
         data_store = MockDataStore()
-        data_store.query_completed_tasks = MagicMock(side_effect=RuntimeError("db error"))
+        data_store.get_completed_tasks_for_tenant = MagicMock(side_effect=RuntimeError("db error"))
         model_store = MockModelStore()
         trainer = CloudTrainer(data_store, model_store, training_lock=lock)
         run = trainer.train_tenant("t1")
@@ -908,7 +928,7 @@ class TestObservability:
         from sigil_ml.training.cloud_trainer import CloudTrainer
 
         data_store = MockDataStore()
-        data_store.query_completed_tasks = MagicMock(side_effect=ValueError("fail"))
+        data_store.get_completed_tasks_for_tenant = MagicMock(side_effect=ValueError("fail"))
         model_store = MockModelStore()
         trainer = CloudTrainer(data_store, model_store)
         run = trainer.train_tenant("t1")

--- a/tests/test_cloud_training.py
+++ b/tests/test_cloud_training.py
@@ -1,0 +1,1122 @@
+"""Tests for the cloud training pipeline (Feature 004).
+
+Tests cover:
+- Training data models (WP01)
+- CloudTrainer per-tenant training (WP02)
+- Batch training and tenant discovery (WP03)
+- Training lock protocol (WP04)
+- Aggregate training (WP05)
+- Observability / structured output (WP06)
+- CLI cloud training flags
+- Feature extraction from data (cloud-compatible extractors)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+from sigil_ml.training.models import (
+    STATUS_FAILED,
+    STATUS_SKIPPED,
+    STATUS_SKIPPED_LOCKED,
+    STATUS_TRAINED,
+    CloudTrainingConfig,
+    TrainingBatch,
+    TrainingRun,
+    TrainingSummary,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_models(tmp_path, monkeypatch):
+    """Redirect model weights to a temp directory so tests don't pollute real config."""
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+
+
+# ---------------------------------------------------------------------------
+# Mock DataStore
+# ---------------------------------------------------------------------------
+
+
+class MockDataStore:
+    """A mock DataStore that supports cloud training operations."""
+
+    def __init__(
+        self,
+        tenants: list[str] | None = None,
+        opted_in_tenants: list[str] | None = None,
+        tasks_per_tenant: dict[str, list[dict]] | None = None,
+        events_per_task: dict[str, list[dict]] | None = None,
+        last_training_ts: dict[str, int | None] | None = None,
+    ) -> None:
+        self._tenants = tenants or []
+        self._opted_in_tenants = opted_in_tenants or []
+        self._tasks = tasks_per_tenant or {}
+        self._events = events_per_task or {}
+        self._last_training_ts = last_training_ts or {}
+        self.recorded_events: list[dict] = []
+        self._ml_events: list[dict] = []
+
+    def list_tenants(self) -> list[str]:
+        return list(self._tenants)
+
+    def list_opted_in_tenants(self) -> list[str]:
+        return list(self._opted_in_tenants)
+
+    def get_last_training_ts(self, tenant_id: str) -> int | None:
+        return self._last_training_ts.get(tenant_id)
+
+    def query_completed_tasks(self, tenant_id: str) -> list[dict]:
+        return list(self._tasks.get(tenant_id, []))
+
+    def query_events_for_task(self, tenant_id: str, task_id: str) -> list[dict]:
+        return list(self._events.get(task_id, []))
+
+    # Existing DataStore protocol methods (fallback path)
+    def get_completed_task_ids(self) -> list[str]:
+        all_ids = []
+        for tasks in self._tasks.values():
+            for t in tasks:
+                all_ids.append(t["id"])
+        return all_ids
+
+    def get_task_by_id(self, task_id: str) -> dict | None:
+        for tasks in self._tasks.values():
+            for t in tasks:
+                if t["id"] == task_id:
+                    return t
+        return None
+
+    def get_events_for_task(self, task_id: str, since: int | None = None) -> list[dict]:
+        return list(self._events.get(task_id, []))
+
+    def insert_ml_event(self, kind: str, endpoint: str, routing: str, latency_ms: int) -> None:
+        self._ml_events.append({
+            "kind": kind,
+            "endpoint": endpoint,
+            "routing": routing,
+            "latency_ms": latency_ms,
+        })
+
+    def commit(self) -> None:
+        pass
+
+    def ensure_tables(self) -> None:
+        pass
+
+    def close(self) -> None:
+        pass
+
+
+class MockModelStore:
+    """A mock ModelStore that stores bytes in memory."""
+
+    def __init__(self) -> None:
+        self._store: dict[str, bytes] = {}
+
+    def load(self, model_name: str) -> bytes | None:
+        return self._store.get(model_name)
+
+    def save(self, model_name: str, data: bytes) -> None:
+        self._store[model_name] = data
+
+    def exists(self, model_name: str) -> bool:
+        return model_name in self._store
+
+
+class MockTrainingLock:
+    """A mock TrainingLock for testing."""
+
+    def __init__(self, locked_tenants: set[str] | None = None) -> None:
+        self._locked = locked_tenants or set()
+        self._acquired: set[str] = set()
+
+    def acquire(self, tenant_id: str) -> bool:
+        if tenant_id in self._locked:
+            return False
+        self._acquired.add(tenant_id)
+        return True
+
+    def release(self, tenant_id: str) -> None:
+        self._acquired.discard(tenant_id)
+
+
+def _make_tasks(n: int, tenant_id: str = "t1") -> list[dict]:
+    """Generate n completed task dicts with varied labels for both classes.
+
+    Half the tasks have high test_fails (stuck heuristic triggers),
+    half have low test_fails (not stuck). This ensures the GradientBoosting
+    classifier has both classes during training.
+    """
+    now_ms = int(time.time() * 1000)
+    tasks = []
+    for i in range(n):
+        # Alternate: even tasks are "stuck" (high test_fails), odd are "ok"
+        if i % 2 == 0:
+            test_fails = 5  # > 3, so stuck heuristic fires
+        else:
+            test_fails = 0  # not stuck
+        tasks.append({
+            "id": f"{tenant_id}-task-{i}",
+            "repo_root": "/tmp/repo",
+            "branch": "feature/test",
+            "phase": "done",
+            "files": json.dumps({"main.py": 5}),
+            "started_at": now_ms - 3600_000,
+            "last_active": now_ms - 60_000,
+            "completed_at": now_ms - 60_000,
+            "commit_count": 2,
+            "test_runs": 5,
+            "test_fails": test_fails,
+        })
+    return tasks
+
+
+def _make_events(task_id: str) -> list[dict]:
+    """Generate sample events for a task."""
+    now_ms = int(time.time() * 1000)
+    return [
+        {"kind": "edit", "source": "editor", "payload": {"file": "main.py"}, "ts": now_ms - 3000_000},
+        {"kind": "edit", "source": "editor", "payload": {"file": "utils.py"}, "ts": now_ms - 2800_000},
+        {"kind": "save", "source": "editor", "payload": {"file": "main.py"}, "ts": now_ms - 2500_000},
+        {"kind": "commit", "source": "git", "payload": {"hash": "abc123"}, "ts": now_ms - 1800_000},
+        {"kind": "phase_change", "source": "sigild", "payload": {"phase": "coding"}, "ts": now_ms - 1200_000},
+    ]
+
+
+# ===========================================================================
+# WP01: Training Data Models
+# ===========================================================================
+
+
+class TestTrainingRun:
+    def test_defaults(self) -> None:
+        run = TrainingRun(tenant_id="t1", status="trained")
+        assert run.tenant_id == "t1"
+        assert run.status == "trained"
+        assert run.models_trained == []
+        assert run.sample_count == 0
+        assert run.duration_ms == 0
+        assert run.error is None
+
+    def test_to_dict(self) -> None:
+        run = TrainingRun(
+            tenant_id="t1",
+            status="trained",
+            models_trained=["stuck", "duration"],
+            sample_count=50,
+            duration_ms=1200,
+        )
+        d = run.to_dict()
+        assert d["tenant_id"] == "t1"
+        assert d["models_trained"] == ["stuck", "duration"]
+        assert d["sample_count"] == 50
+        assert "error" not in d  # None errors excluded
+
+    def test_to_dict_with_error(self) -> None:
+        run = TrainingRun(tenant_id="t1", status="failed", error="boom")
+        d = run.to_dict()
+        assert d["error"] == "boom"
+
+    def test_to_dict_with_timestamps(self) -> None:
+        now = datetime.now(timezone.utc)
+        run = TrainingRun(
+            tenant_id="t1",
+            status="trained",
+            started_at=now,
+            completed_at=now,
+        )
+        d = run.to_dict()
+        assert "started_at" in d
+        assert "completed_at" in d
+        assert d["started_at"].endswith("+00:00")
+
+    def test_to_dict_with_data_freshness(self) -> None:
+        run = TrainingRun(
+            tenant_id="t1", status="trained", data_freshness_sec=45.2
+        )
+        d = run.to_dict()
+        assert d["data_freshness_sec"] == 45.2
+
+    def test_to_json(self) -> None:
+        run = TrainingRun(tenant_id="t1", status="trained")
+        j = run.to_json()
+        parsed = json.loads(j)
+        assert parsed["tenant_id"] == "t1"
+
+    def test_to_json_compact(self) -> None:
+        run = TrainingRun(tenant_id="t1", status="trained")
+        j = run.to_json(indent=None)
+        assert "\n" not in j
+
+    def test_status_constants(self) -> None:
+        assert STATUS_TRAINED == "trained"
+        assert STATUS_SKIPPED == "skipped"
+        assert STATUS_SKIPPED_LOCKED == "skipped_locked"
+        assert STATUS_FAILED == "failed"
+
+
+class TestTrainingBatch:
+    def test_empty(self) -> None:
+        batch = TrainingBatch()
+        assert batch.total == 0
+        assert batch.trained == 0
+        assert batch.skipped == 0
+        assert batch.failed == 0
+
+    def test_counts(self) -> None:
+        batch = TrainingBatch(runs=[
+            TrainingRun(tenant_id="t1", status="trained"),
+            TrainingRun(tenant_id="t2", status="trained"),
+            TrainingRun(tenant_id="t3", status="skipped"),
+            TrainingRun(tenant_id="t4", status="skipped_locked"),
+            TrainingRun(tenant_id="t5", status="failed"),
+        ])
+        assert batch.total == 5
+        assert batch.trained == 2
+        assert batch.skipped == 2  # skipped + skipped_locked
+        assert batch.failed == 1
+
+    def test_status_breakdown(self) -> None:
+        batch = TrainingBatch(runs=[
+            TrainingRun(tenant_id="t1", status="trained"),
+            TrainingRun(tenant_id="t2", status="skipped"),
+            TrainingRun(tenant_id="t3", status="skipped_locked"),
+            TrainingRun(tenant_id="t4", status="failed"),
+            TrainingRun(tenant_id="t5", status="trained"),
+        ])
+        breakdown = batch.status_breakdown
+        assert breakdown["trained"] == 2
+        assert breakdown["skipped"] == 1
+        assert breakdown["skipped_locked"] == 1
+        assert breakdown["failed"] == 1
+
+    def test_to_dict(self) -> None:
+        batch = TrainingBatch(
+            runs=[TrainingRun(tenant_id="t1", status="trained")],
+            total_duration_ms=500,
+        )
+        d = batch.to_dict()
+        assert d["total"] == 1
+        assert d["trained"] == 1
+        assert d["total_duration_ms"] == 500
+        assert "status_breakdown" in d
+        assert len(d["runs"]) == 1
+
+    def test_to_json(self) -> None:
+        batch = TrainingBatch()
+        j = batch.to_json()
+        parsed = json.loads(j)
+        assert parsed["total"] == 0
+
+
+class TestCloudTrainingConfig:
+    def test_defaults(self) -> None:
+        cfg = CloudTrainingConfig()
+        assert cfg.min_interval_sec == 3600
+        assert cfg.min_tasks == 10
+        assert cfg.max_tasks_per_tenant == 1000
+        assert cfg.aggregate_min_tenants == 3
+
+    def test_custom_values(self) -> None:
+        cfg = CloudTrainingConfig(
+            min_interval_sec=1800,
+            min_tasks=5,
+            max_tasks_per_tenant=500,
+            aggregate_min_tenants=2,
+        )
+        assert cfg.min_interval_sec == 1800
+        assert cfg.min_tasks == 5
+
+
+class TestTrainingSummary:
+    def test_to_dict(self) -> None:
+        summary = TrainingSummary(
+            mode="batch",
+            total_tenants=10,
+            trained=8,
+            skipped=1,
+            failed=1,
+            total_samples=500,
+        )
+        d = summary.to_dict()
+        assert d["mode"] == "batch"
+        assert d["total_tenants"] == 10
+
+    def test_to_json(self) -> None:
+        summary = TrainingSummary(mode="single")
+        j = summary.to_json()
+        parsed = json.loads(j)
+        assert parsed["mode"] == "single"
+
+
+# ===========================================================================
+# WP02: Per-Tenant Training Logic
+# ===========================================================================
+
+
+class TestCloudTrainerPerTenant:
+    def _make_trainer(
+        self,
+        tasks: list[dict] | None = None,
+        events: dict[str, list[dict]] | None = None,
+        last_training_ts: dict[str, int | None] | None = None,
+        config: CloudTrainingConfig | None = None,
+        lock: Any | None = None,
+    ):
+        from sigil_ml.training.cloud_trainer import CloudTrainer
+
+        tenant_tasks = {"t1": tasks or []}
+        data_store = MockDataStore(
+            tenants=["t1"],
+            tasks_per_tenant=tenant_tasks,
+            events_per_task=events or {},
+            last_training_ts=last_training_ts or {},
+        )
+        model_store = MockModelStore()
+        return CloudTrainer(
+            data_store=data_store,
+            model_store=model_store,
+            config=config or CloudTrainingConfig(),
+            training_lock=lock,
+        )
+
+    def test_insufficient_data_uses_synthetic(self) -> None:
+        """Tenant with < 10 tasks gets synthetic data training."""
+        trainer = self._make_trainer(tasks=_make_tasks(5, "t1"))
+        run = trainer.train_tenant("t1")
+        assert run.status == "trained"
+        assert run.sample_count == 500  # synthetic
+        assert "stuck" in run.models_trained
+        assert "duration" in run.models_trained
+
+    def test_sufficient_data_trains_real(self) -> None:
+        """Tenant with >= 10 tasks trains on real data."""
+        tasks = _make_tasks(15, "t1")
+        events = {t["id"]: _make_events(t["id"]) for t in tasks}
+        trainer = self._make_trainer(tasks=tasks, events=events)
+        run = trainer.train_tenant("t1")
+        assert run.status == "trained"
+        assert run.sample_count == 15
+        assert "stuck" in run.models_trained
+        assert "duration" in run.models_trained
+
+    def test_boundary_exactly_min_tasks(self) -> None:
+        """Exactly min_tasks (10) tasks trains on real data, not synthetic."""
+        tasks = _make_tasks(10, "t1")
+        events = {t["id"]: _make_events(t["id"]) for t in tasks}
+        trainer = self._make_trainer(tasks=tasks, events=events)
+        run = trainer.train_tenant("t1")
+        assert run.status == "trained"
+        assert run.sample_count == 10
+
+    def test_custom_threshold(self) -> None:
+        """Custom min_tasks=5 lowers the bar."""
+        tasks = _make_tasks(7, "t1")
+        events = {t["id"]: _make_events(t["id"]) for t in tasks}
+        cfg = CloudTrainingConfig(min_tasks=5)
+        trainer = self._make_trainer(tasks=tasks, events=events, config=cfg)
+        run = trainer.train_tenant("t1")
+        assert run.status == "trained"
+        assert run.sample_count == 7
+
+    def test_interval_skip_recent(self) -> None:
+        """Tenant trained 30 minutes ago is skipped."""
+        now_ms = int(time.time() * 1000)
+        thirty_min_ago = now_ms - 1800_000  # 30 minutes ago
+        trainer = self._make_trainer(
+            tasks=_make_tasks(20, "t1"),
+            last_training_ts={"t1": thirty_min_ago},
+        )
+        run = trainer.train_tenant("t1")
+        assert run.status == "skipped"
+
+    def test_interval_allow_old(self) -> None:
+        """Tenant trained 2 hours ago proceeds."""
+        now_ms = int(time.time() * 1000)
+        two_hours_ago = now_ms - 7200_000
+        tasks = _make_tasks(15, "t1")
+        events = {t["id"]: _make_events(t["id"]) for t in tasks}
+        trainer = self._make_trainer(
+            tasks=tasks,
+            events=events,
+            last_training_ts={"t1": two_hours_ago},
+        )
+        run = trainer.train_tenant("t1")
+        assert run.status == "trained"
+
+    def test_never_trained_proceeds(self) -> None:
+        """Tenant never trained (None timestamp) proceeds."""
+        tasks = _make_tasks(15, "t1")
+        events = {t["id"]: _make_events(t["id"]) for t in tasks}
+        trainer = self._make_trainer(
+            tasks=tasks,
+            events=events,
+            last_training_ts={"t1": None},
+        )
+        run = trainer.train_tenant("t1")
+        assert run.status == "trained"
+
+    def test_duration_ms_captured(self) -> None:
+        """TrainingRun captures duration."""
+        trainer = self._make_trainer(tasks=_make_tasks(5, "t1"))
+        run = trainer.train_tenant("t1")
+        assert run.duration_ms >= 0
+
+    def test_error_returns_failed_run(self) -> None:
+        """Errors during training return a failed TrainingRun."""
+        from sigil_ml.training.cloud_trainer import CloudTrainer
+
+        # DataStore that raises on query_completed_tasks
+        data_store = MockDataStore()
+        data_store.query_completed_tasks = MagicMock(side_effect=ValueError("boom"))
+        model_store = MockModelStore()
+        trainer = CloudTrainer(data_store, model_store)
+        run = trainer.train_tenant("t1")
+        assert run.status == "failed"
+        assert "boom" in run.error
+
+    def test_models_saved_to_model_store(self) -> None:
+        """Weights are saved via ModelStore with tenant-scoped prefix."""
+        tasks = _make_tasks(15, "t1")
+        events = {t["id"]: _make_events(t["id"]) for t in tasks}
+        trainer = self._make_trainer(tasks=tasks, events=events)
+        model_store = trainer.model_store
+        run = trainer.train_tenant("t1")
+        assert run.status == "trained"
+        # Check model store has tenant-scoped keys
+        assert model_store.exists("t1/stuck")
+        assert model_store.exists("t1/duration")
+
+
+# ===========================================================================
+# WP03: Batch Training & Tenant Discovery
+# ===========================================================================
+
+
+class TestBatchTraining:
+    def test_batch_multiple_tenants(self) -> None:
+        from sigil_ml.training.cloud_trainer import CloudTrainer
+
+        tasks_t1 = _make_tasks(15, "t1")
+        tasks_t2 = _make_tasks(15, "t2")
+        events_t1 = {t["id"]: _make_events(t["id"]) for t in tasks_t1}
+        events_t2 = {t["id"]: _make_events(t["id"]) for t in tasks_t2}
+
+        data_store = MockDataStore(
+            tenants=["t1", "t2"],
+            tasks_per_tenant={"t1": tasks_t1, "t2": tasks_t2},
+            events_per_task={**events_t1, **events_t2},
+        )
+        model_store = MockModelStore()
+        trainer = CloudTrainer(data_store, model_store)
+        batch = trainer.train_all_tenants()
+
+        assert batch.total == 2
+        assert batch.trained == 2
+        assert batch.failed == 0
+
+    def test_batch_zero_tenants(self) -> None:
+        from sigil_ml.training.cloud_trainer import CloudTrainer
+
+        data_store = MockDataStore(tenants=[])
+        model_store = MockModelStore()
+        trainer = CloudTrainer(data_store, model_store)
+        batch = trainer.train_all_tenants()
+
+        assert batch.total == 0
+        assert batch.trained == 0
+        assert batch.skipped == 0
+        assert batch.failed == 0
+
+    def test_batch_fault_isolation(self) -> None:
+        """One tenant's failure doesn't prevent others from training."""
+        from sigil_ml.training.cloud_trainer import CloudTrainer
+
+        tasks_t2 = _make_tasks(15, "t2")
+        events_t2 = {t["id"]: _make_events(t["id"]) for t in tasks_t2}
+
+        data_store = MockDataStore(
+            tenants=["t1", "t2"],
+            tasks_per_tenant={"t1": [], "t2": tasks_t2},
+            events_per_task=events_t2,
+        )
+        # Make t1 fail by having query_completed_tasks raise for t1
+        original_query = data_store.query_completed_tasks
+
+        def failing_query(tenant_id: str) -> list[dict]:
+            if tenant_id == "t1":
+                raise ConnectionError("DB unreachable for t1")
+            return original_query(tenant_id)
+
+        data_store.query_completed_tasks = failing_query  # type: ignore[assignment]
+        model_store = MockModelStore()
+        trainer = CloudTrainer(data_store, model_store)
+        batch = trainer.train_all_tenants()
+
+        assert batch.total == 2
+        assert batch.trained == 1  # t2 succeeded
+        assert batch.failed == 1  # t1 failed
+
+        # Verify t1 is the failed one
+        t1_run = [r for r in batch.runs if r.tenant_id == "t1"][0]
+        assert t1_run.status == "failed"
+        t2_run = [r for r in batch.runs if r.tenant_id == "t2"][0]
+        assert t2_run.status == "trained"
+
+    def test_batch_all_skipped(self) -> None:
+        """All tenants skipped (recently trained) returns clean batch."""
+        from sigil_ml.training.cloud_trainer import CloudTrainer
+
+        now_ms = int(time.time() * 1000)
+        recent = now_ms - 600_000  # 10 minutes ago
+
+        data_store = MockDataStore(
+            tenants=["t1", "t2"],
+            tasks_per_tenant={"t1": _make_tasks(15, "t1"), "t2": _make_tasks(15, "t2")},
+            last_training_ts={"t1": recent, "t2": recent},
+        )
+        model_store = MockModelStore()
+        trainer = CloudTrainer(data_store, model_store)
+        batch = trainer.train_all_tenants()
+
+        assert batch.total == 2
+        assert batch.trained == 0
+        assert batch.skipped == 2
+        assert batch.failed == 0
+
+
+class TestTenantDiscovery:
+    def test_discover_eligible(self) -> None:
+        from sigil_ml.training.tenant_discovery import discover_eligible_tenants
+
+        ds = MockDataStore(tenants=["a", "b", "c"])
+        result = discover_eligible_tenants(ds)
+        assert result == ["a", "b", "c"]
+
+    def test_discover_empty(self) -> None:
+        from sigil_ml.training.tenant_discovery import discover_eligible_tenants
+
+        ds = MockDataStore(tenants=[])
+        result = discover_eligible_tenants(ds)
+        assert result == []
+
+    def test_discover_opted_in(self) -> None:
+        from sigil_ml.training.tenant_discovery import discover_opted_in_tenants
+
+        ds = MockDataStore(opted_in_tenants=["a", "c"])
+        result = discover_opted_in_tenants(ds)
+        assert result == ["a", "c"]
+
+
+# ===========================================================================
+# WP04: Concurrent Training Lock
+# ===========================================================================
+
+
+class TestTrainingLock:
+    def test_lock_protocol(self) -> None:
+        from sigil_ml.training.locking import TrainingLock
+
+        lock = MockTrainingLock()
+        assert isinstance(lock, TrainingLock)
+
+    def test_lock_acquire_release(self) -> None:
+        lock = MockTrainingLock()
+        assert lock.acquire("t1") is True
+        lock.release("t1")
+
+    def test_lock_blocked(self) -> None:
+        lock = MockTrainingLock(locked_tenants={"t1"})
+        assert lock.acquire("t1") is False
+        assert lock.acquire("t2") is True  # different tenant OK
+
+    def test_trainer_with_lock_skips_locked(self) -> None:
+        """train_tenant returns skipped_locked when lock is held."""
+        from sigil_ml.training.cloud_trainer import CloudTrainer
+
+        lock = MockTrainingLock(locked_tenants={"t1"})
+        data_store = MockDataStore(
+            tenants=["t1"],
+            tasks_per_tenant={"t1": _make_tasks(20, "t1")},
+        )
+        model_store = MockModelStore()
+        trainer = CloudTrainer(data_store, model_store, training_lock=lock)
+        run = trainer.train_tenant("t1")
+        assert run.status == "skipped_locked"
+
+    def test_trainer_without_lock_works(self) -> None:
+        """training_lock=None means no locking overhead."""
+        from sigil_ml.training.cloud_trainer import CloudTrainer
+
+        data_store = MockDataStore(
+            tenants=["t1"],
+            tasks_per_tenant={"t1": _make_tasks(5, "t1")},
+        )
+        model_store = MockModelStore()
+        trainer = CloudTrainer(data_store, model_store, training_lock=None)
+        run = trainer.train_tenant("t1")
+        assert run.status == "trained"  # proceeds without lock
+
+    def test_lock_released_on_failure(self) -> None:
+        """Lock is released even if training fails."""
+        from sigil_ml.training.cloud_trainer import CloudTrainer
+
+        lock = MockTrainingLock()
+        data_store = MockDataStore()
+        data_store.query_completed_tasks = MagicMock(side_effect=RuntimeError("db error"))
+        model_store = MockModelStore()
+        trainer = CloudTrainer(data_store, model_store, training_lock=lock)
+        run = trainer.train_tenant("t1")
+        assert run.status == "failed"
+        # Lock should have been released (not in acquired set)
+        assert "t1" not in lock._acquired
+
+    def test_lock_checked_before_interval(self) -> None:
+        """Lock check happens before interval check (cheapest first)."""
+        from sigil_ml.training.cloud_trainer import CloudTrainer
+
+        lock = MockTrainingLock(locked_tenants={"t1"})
+        now_ms = int(time.time() * 1000)
+        # Even though interval would allow training, lock prevents it
+        data_store = MockDataStore(
+            tenants=["t1"],
+            tasks_per_tenant={"t1": _make_tasks(20, "t1")},
+            last_training_ts={"t1": now_ms - 7200_000},  # 2 hours ago, would be OK
+        )
+        model_store = MockModelStore()
+        trainer = CloudTrainer(data_store, model_store, training_lock=lock)
+        run = trainer.train_tenant("t1")
+        assert run.status == "skipped_locked"
+
+
+class TestDataStoreTrainingLock:
+    def test_acquire_delegates_to_data_store(self) -> None:
+        from sigil_ml.training.locking import DataStoreTrainingLock
+
+        ds = MagicMock()
+        ds.acquire_training_lock = MagicMock(return_value=True)
+        lock = DataStoreTrainingLock(ds, stale_timeout_sec=7200)
+        result = lock.acquire("t1")
+        assert result is True
+        ds.acquire_training_lock.assert_called_once()
+
+    def test_release_delegates_to_data_store(self) -> None:
+        from sigil_ml.training.locking import DataStoreTrainingLock
+
+        ds = MagicMock()
+        ds.release_training_lock = MagicMock()
+        lock = DataStoreTrainingLock(ds)
+        lock.release("t1")
+        ds.release_training_lock.assert_called_once_with("t1")
+
+    def test_acquire_graceful_no_method(self) -> None:
+        """If DataStore doesn't have lock methods, treat as acquired."""
+        from sigil_ml.training.locking import DataStoreTrainingLock
+
+        ds = MockDataStore()  # doesn't have acquire_training_lock
+        # Remove the method if it exists
+        if hasattr(ds, "acquire_training_lock"):
+            delattr(ds, "acquire_training_lock")
+        lock = DataStoreTrainingLock(ds)
+        result = lock.acquire("t1")
+        assert result is True  # graceful fallback
+
+    def test_release_graceful_no_method(self) -> None:
+        """If DataStore doesn't have release method, no-op."""
+        from sigil_ml.training.locking import DataStoreTrainingLock
+
+        ds = MockDataStore()
+        if hasattr(ds, "release_training_lock"):
+            delattr(ds, "release_training_lock")
+        lock = DataStoreTrainingLock(ds)
+        # Should not raise
+        lock.release("t1")
+
+
+# ===========================================================================
+# WP05: Aggregate Model Training
+# ===========================================================================
+
+
+class TestAggregateTraining:
+    def test_aggregate_pools_opted_in_data(self) -> None:
+        from sigil_ml.training.cloud_trainer import AGGREGATE_TENANT_ID, CloudTrainer
+
+        tasks_t1 = _make_tasks(15, "t1")
+        tasks_t2 = _make_tasks(15, "t2")
+        events_t1 = {t["id"]: _make_events(t["id"]) for t in tasks_t1}
+        events_t2 = {t["id"]: _make_events(t["id"]) for t in tasks_t2}
+
+        data_store = MockDataStore(
+            opted_in_tenants=["t1", "t2"],
+            tasks_per_tenant={"t1": tasks_t1, "t2": tasks_t2},
+            events_per_task={**events_t1, **events_t2},
+        )
+        model_store = MockModelStore()
+        trainer = CloudTrainer(data_store, model_store)
+        run = trainer.train_aggregate()
+
+        assert run.tenant_id == AGGREGATE_TENANT_ID
+        assert run.status == "trained"
+        assert run.sample_count == 30  # 15 + 15
+        assert "stuck" in run.models_trained
+        assert "duration" in run.models_trained
+
+    def test_aggregate_zero_tenants(self) -> None:
+        from sigil_ml.training.cloud_trainer import AGGREGATE_TENANT_ID, CloudTrainer
+
+        data_store = MockDataStore(opted_in_tenants=[])
+        model_store = MockModelStore()
+        trainer = CloudTrainer(data_store, model_store)
+        run = trainer.train_aggregate()
+
+        assert run.tenant_id == AGGREGATE_TENANT_ID
+        assert run.status == "skipped"
+        assert "No opted-in tenants" in run.error
+
+    def test_aggregate_low_tenant_warning(self) -> None:
+        """Fewer than aggregate_min_tenants warns but proceeds."""
+        from sigil_ml.training.cloud_trainer import CloudTrainer
+
+        tasks = _make_tasks(15, "t1")
+        events = {t["id"]: _make_events(t["id"]) for t in tasks}
+
+        data_store = MockDataStore(
+            opted_in_tenants=["t1"],
+            tasks_per_tenant={"t1": tasks},
+            events_per_task=events,
+        )
+        model_store = MockModelStore()
+        cfg = CloudTrainingConfig(aggregate_min_tenants=3)
+        trainer = CloudTrainer(data_store, model_store, cfg)
+        run = trainer.train_aggregate()
+
+        assert run.status == "trained"  # proceeds despite warning
+        assert run.error is not None
+        assert "recommended minimum" in run.error
+
+    def test_aggregate_enough_tenants_no_warning(self) -> None:
+        from sigil_ml.training.cloud_trainer import CloudTrainer
+
+        all_tasks = {}
+        all_events = {}
+        tenants = ["t1", "t2", "t3"]
+        for t in tenants:
+            tasks = _make_tasks(15, t)
+            all_tasks[t] = tasks
+            for task in tasks:
+                all_events[task["id"]] = _make_events(task["id"])
+
+        data_store = MockDataStore(
+            opted_in_tenants=tenants,
+            tasks_per_tenant=all_tasks,
+            events_per_task=all_events,
+        )
+        model_store = MockModelStore()
+        cfg = CloudTrainingConfig(aggregate_min_tenants=3)
+        trainer = CloudTrainer(data_store, model_store, cfg)
+        run = trainer.train_aggregate()
+
+        assert run.status == "trained"
+        assert run.error is None  # no warning
+
+    def test_aggregate_sampling_caps(self) -> None:
+        """Per-tenant sampling cap limits contribution."""
+        from sigil_ml.training.cloud_trainer import CloudTrainer
+
+        # t1 has 50 tasks, t2 has 5. Cap at 10.
+        tasks_t1 = _make_tasks(50, "t1")
+        tasks_t2 = _make_tasks(5, "t2")
+        events = {}
+        for t in tasks_t1 + tasks_t2:
+            events[t["id"]] = _make_events(t["id"])
+
+        data_store = MockDataStore(
+            opted_in_tenants=["t1", "t2"],
+            tasks_per_tenant={"t1": tasks_t1, "t2": tasks_t2},
+            events_per_task=events,
+        )
+        model_store = MockModelStore()
+        cfg = CloudTrainingConfig(max_tasks_per_tenant=10, aggregate_min_tenants=1)
+        trainer = CloudTrainer(data_store, model_store, cfg)
+        run = trainer.train_aggregate()
+
+        assert run.status == "trained"
+        # t1 capped at 10, t2 all 5 = 15 total
+        assert run.sample_count == 15
+
+    def test_aggregate_model_saved_to_aggregate_prefix(self) -> None:
+        from sigil_ml.training.cloud_trainer import AGGREGATE_TENANT_ID, CloudTrainer
+
+        tasks = _make_tasks(15, "t1")
+        events = {t["id"]: _make_events(t["id"]) for t in tasks}
+
+        data_store = MockDataStore(
+            opted_in_tenants=["t1"],
+            tasks_per_tenant={"t1": tasks},
+            events_per_task=events,
+        )
+        model_store = MockModelStore()
+        cfg = CloudTrainingConfig(aggregate_min_tenants=1)
+        trainer = CloudTrainer(data_store, model_store, cfg)
+        run = trainer.train_aggregate()
+
+        assert run.status == "trained"
+        # Models saved with aggregate prefix
+        assert model_store.exists(f"{AGGREGATE_TENANT_ID}/stuck")
+        assert model_store.exists(f"{AGGREGATE_TENANT_ID}/duration")
+
+
+# ===========================================================================
+# WP06: Observability
+# ===========================================================================
+
+
+class TestObservability:
+    def test_audit_event_on_success(self) -> None:
+        """Successful training records an audit event."""
+        from sigil_ml.training.cloud_trainer import CloudTrainer
+
+        tasks = _make_tasks(15, "t1")
+        events = {t["id"]: _make_events(t["id"]) for t in tasks}
+        data_store = MockDataStore(
+            tenants=["t1"],
+            tasks_per_tenant={"t1": tasks},
+            events_per_task=events,
+        )
+        model_store = MockModelStore()
+        trainer = CloudTrainer(data_store, model_store)
+        trainer.train_tenant("t1")
+
+        assert len(data_store._ml_events) > 0
+        event = data_store._ml_events[0]
+        assert event["kind"] == "training"
+        assert event["routing"] == "t1"
+
+    def test_audit_event_on_failure(self) -> None:
+        """Failed training records an audit event."""
+        from sigil_ml.training.cloud_trainer import CloudTrainer
+
+        data_store = MockDataStore()
+        data_store.query_completed_tasks = MagicMock(side_effect=ValueError("fail"))
+        model_store = MockModelStore()
+        trainer = CloudTrainer(data_store, model_store)
+        run = trainer.train_tenant("t1")
+        assert run.status == "failed"
+        assert len(data_store._ml_events) > 0
+
+    def test_audit_event_on_skip(self) -> None:
+        """Skipped training records an audit event."""
+        from sigil_ml.training.cloud_trainer import CloudTrainer
+
+        now_ms = int(time.time() * 1000)
+        data_store = MockDataStore(
+            tenants=["t1"],
+            tasks_per_tenant={"t1": _make_tasks(15, "t1")},
+            last_training_ts={"t1": now_ms - 600_000},
+        )
+        model_store = MockModelStore()
+        trainer = CloudTrainer(data_store, model_store)
+        run = trainer.train_tenant("t1")
+        assert run.status == "skipped"
+        assert len(data_store._ml_events) > 0
+
+    def test_batch_audit_event(self) -> None:
+        """Batch training records a batch-level audit event."""
+        from sigil_ml.training.cloud_trainer import CloudTrainer
+
+        data_store = MockDataStore(tenants=["t1"])
+        data_store._tasks["t1"] = _make_tasks(5, "t1")
+        model_store = MockModelStore()
+        trainer = CloudTrainer(data_store, model_store)
+        trainer.train_all_tenants()
+
+        # Should have per-tenant + batch-level events
+        batch_events = [
+            e for e in data_store._ml_events if e["kind"] == "batch_training"
+        ]
+        assert len(batch_events) == 1
+        assert batch_events[0]["routing"] == "__batch__"
+
+    def test_training_run_json_valid(self) -> None:
+        """TrainingRun produces valid JSON."""
+        run = TrainingRun(
+            tenant_id="t1",
+            status="trained",
+            models_trained=["stuck", "duration"],
+            sample_count=100,
+            duration_ms=5000,
+        )
+        j = run.to_json()
+        parsed = json.loads(j)
+        assert parsed["tenant_id"] == "t1"
+        assert parsed["sample_count"] == 100
+
+    def test_batch_json_valid(self) -> None:
+        """TrainingBatch produces valid JSON."""
+        batch = TrainingBatch(
+            runs=[
+                TrainingRun(tenant_id="t1", status="trained", models_trained=["stuck"]),
+                TrainingRun(tenant_id="t2", status="failed", error="boom"),
+            ],
+            total_duration_ms=3000,
+        )
+        j = batch.to_json()
+        parsed = json.loads(j)
+        assert parsed["total"] == 2
+        assert parsed["trained"] == 1
+        assert parsed["failed"] == 1
+        assert len(parsed["runs"]) == 2
+
+
+# ===========================================================================
+# Feature Extraction (cloud-compatible)
+# ===========================================================================
+
+
+class TestCloudFeatureExtraction:
+    def test_stuck_features_from_data(self) -> None:
+        from sigil_ml.features import extract_stuck_features_from_data
+
+        now_ms = int(time.time() * 1000)
+        task = {
+            "started_at": now_ms - 3600_000,
+            "last_active": now_ms - 60_000,
+            "test_fails": 3,
+        }
+        events = [
+            {"kind": "edit", "payload": {"file": "main.py"}, "ts": now_ms - 3000_000},
+            {"kind": "edit", "payload": {"file": "utils.py"}, "ts": now_ms - 2800_000},
+            {"kind": "commit", "payload": {}, "ts": now_ms - 1800_000},
+            {"kind": "phase_change", "payload": {}, "ts": now_ms - 1200_000},
+        ]
+        feats = extract_stuck_features_from_data(task, events)
+        assert feats["test_failure_count"] == 3.0
+        assert feats["session_length_sec"] > 0
+        assert feats["edit_velocity"] >= 0
+        assert 0 <= feats["file_switch_rate"] <= 1.0
+
+    def test_stuck_features_empty_events(self) -> None:
+        from sigil_ml.features import extract_stuck_features_from_data
+
+        now_ms = int(time.time() * 1000)
+        task = {
+            "started_at": now_ms - 3600_000,
+            "last_active": now_ms - 60_000,
+            "test_fails": 0,
+        }
+        feats = extract_stuck_features_from_data(task, [])
+        assert feats["test_failure_count"] == 0.0
+        assert feats["edit_velocity"] == 0.0
+
+    def test_stuck_features_no_started_at(self) -> None:
+        from sigil_ml.features import extract_stuck_features_from_data
+
+        feats = extract_stuck_features_from_data({}, [])
+        assert feats["session_length_sec"] >= 1.0  # min 1.0
+
+    def test_duration_features_from_data(self) -> None:
+        from sigil_ml.features import extract_duration_features_from_data
+
+        now_ms = int(time.time() * 1000)
+        task = {
+            "started_at": now_ms - 3600_000,
+            "branch": "feature/add-widget",
+            "files": json.dumps({"main.py": 5, "utils.py": 3}),
+        }
+        events = [
+            {"kind": "edit", "payload": {"file": "main.py"}, "ts": now_ms - 3000_000},
+            {"kind": "save", "payload": {"file": "main.py"}, "ts": now_ms - 2500_000},
+        ]
+        feats = extract_duration_features_from_data(task, events)
+        assert feats["file_count"] == 2.0
+        assert feats["total_edits"] == 2.0
+        assert 0 <= feats["time_of_day_hour"] < 24
+        assert feats["branch_name_length"] == len("feature/add-widget")
+
+    def test_duration_features_missing_files(self) -> None:
+        from sigil_ml.features import extract_duration_features_from_data
+
+        feats = extract_duration_features_from_data({}, [])
+        assert feats["file_count"] == 0.0
+        assert feats["branch_name_length"] == 0.0
+
+
+# ===========================================================================
+# CLI Cloud Training Flags
+# ===========================================================================
+
+
+class TestCLICloudFlags:
+    def test_cloud_mode_requires_target(self) -> None:
+        """--mode cloud without --tenant/--all-tenants/--aggregate errors."""
+        import subprocess
+
+        result = subprocess.run(
+            [".venv/bin/python", "-m", "sigil_ml.cli", "train", "--mode", "cloud"],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode != 0
+        assert "requires --tenant" in result.stderr
+
+    def test_cloud_mode_mutual_exclusivity(self) -> None:
+        """--tenant and --all-tenants together errors."""
+        import subprocess
+
+        result = subprocess.run(
+            [
+                ".venv/bin/python", "-m", "sigil_ml.cli",
+                "train", "--mode", "cloud",
+                "--tenant", "t1", "--all-tenants",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode != 0
+        assert "mutually exclusive" in result.stderr
+
+    def test_cloud_mode_missing_env_vars(self) -> None:
+        """Missing SIGIL_POSTGRES_URL errors."""
+        import subprocess
+
+        env = {"PATH": os.environ.get("PATH", ""), "HOME": os.environ.get("HOME", "")}
+        result = subprocess.run(
+            [
+                ".venv/bin/python", "-m", "sigil_ml.cli",
+                "train", "--mode", "cloud", "--tenant", "t1",
+            ],
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        assert result.returncode != 0
+        assert "SIGIL_POSTGRES_URL" in result.stderr
+
+    def test_local_mode_default(self) -> None:
+        """train --help shows --mode flag."""
+        import subprocess
+
+        result = subprocess.run(
+            [".venv/bin/python", "-m", "sigil_ml.cli", "train", "--help"],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+        assert "--mode" in result.stdout
+        assert "--tenant" in result.stdout
+        assert "--all-tenants" in result.stdout
+        assert "--aggregate" in result.stdout
+        assert "--min-interval" in result.stdout
+        assert "--min-tasks" in result.stdout
+        assert "--json" in result.stdout

--- a/tests/test_model_store.py
+++ b/tests/test_model_store.py
@@ -1,0 +1,220 @@
+"""Tests for ModelStore implementations: LocalModelStore, CachedModelStore."""
+
+from __future__ import annotations
+
+import threading
+import time
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from sigil_ml.storage.model_store import CachedModelStore, LocalModelStore
+
+
+# ---------------------------------------------------------------------------
+# LocalModelStore round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestLocalModelStore:
+    """Verify LocalModelStore save/load/exists round-trip."""
+
+    def test_round_trip(self, tmp_path: Path) -> None:
+        store = LocalModelStore(base_dir=tmp_path)
+        data = b"model-weights-bytes"
+        store.save("my_model", data)
+
+        assert store.exists("my_model")
+        loaded = store.load("my_model")
+        assert loaded == data
+
+    def test_load_missing_returns_none(self, tmp_path: Path) -> None:
+        store = LocalModelStore(base_dir=tmp_path)
+        assert store.load("nonexistent") is None
+
+    def test_exists_false_when_missing(self, tmp_path: Path) -> None:
+        store = LocalModelStore(base_dir=tmp_path)
+        assert not store.exists("nonexistent")
+
+    def test_overwrite(self, tmp_path: Path) -> None:
+        store = LocalModelStore(base_dir=tmp_path)
+        store.save("m", b"v1")
+        store.save("m", b"v2")
+        assert store.load("m") == b"v2"
+
+    def test_nested_model_name(self, tmp_path: Path) -> None:
+        """Model names with '/' create sub-directories (tenant-scoped keys)."""
+        store = LocalModelStore(base_dir=tmp_path)
+        store.save("tenant-a/stuck", b"data")
+        assert store.exists("tenant-a/stuck")
+        assert store.load("tenant-a/stuck") == b"data"
+
+
+# ---------------------------------------------------------------------------
+# CachedModelStore
+# ---------------------------------------------------------------------------
+
+
+def _make_inner() -> MagicMock:
+    """Create a mock inner ModelStore."""
+    inner = MagicMock()
+    inner.load = MagicMock(return_value=b"bytes-from-inner")
+    inner.save = MagicMock()
+    inner.exists = MagicMock(return_value=True)
+    return inner
+
+
+class TestCachedModelStoreTTL:
+    """TTL expiration behavior."""
+
+    def test_cache_hit_within_ttl(self) -> None:
+        inner = _make_inner()
+        cache = CachedModelStore(inner, ttl_seconds=10.0, max_entries=10)
+
+        first = cache.load("m")
+        second = cache.load("m")
+
+        assert first == second == b"bytes-from-inner"
+        # Inner store should only be called once (cache hit on second load)
+        assert inner.load.call_count == 1
+
+    def test_cache_expired_after_ttl(self) -> None:
+        inner = _make_inner()
+        cache = CachedModelStore(inner, ttl_seconds=0.05, max_entries=10)
+
+        cache.load("m")
+        time.sleep(0.1)  # wait for TTL expiration
+        cache.load("m")
+
+        # Should call inner twice: first load + expired reload
+        assert inner.load.call_count == 2
+
+    def test_save_updates_cache(self) -> None:
+        inner = _make_inner()
+        cache = CachedModelStore(inner, ttl_seconds=60.0, max_entries=10)
+
+        cache.save("m", b"new-data")
+        # Now load should come from cache, not inner
+        result = cache.load("m")
+
+        assert result == b"new-data"
+        inner.load.assert_not_called()
+
+    def test_exists_uses_cache(self) -> None:
+        inner = _make_inner()
+        cache = CachedModelStore(inner, ttl_seconds=60.0, max_entries=10)
+
+        cache.load("m")  # populate cache
+        assert cache.exists("m") is True
+        inner.exists.assert_not_called()
+
+
+class TestCachedModelStoreLRU:
+    """LRU eviction behavior."""
+
+    def test_eviction_at_capacity(self) -> None:
+        inner = _make_inner()
+        inner.load = MagicMock(side_effect=lambda name: name.encode())
+        cache = CachedModelStore(inner, ttl_seconds=60.0, max_entries=3)
+
+        # Fill to capacity
+        cache.load("a")
+        cache.load("b")
+        cache.load("c")
+
+        # Adding a 4th should evict the oldest
+        cache.load("d")
+
+        # 'a' was oldest (least recently used), so inner should be called again
+        inner.load.reset_mock()
+        cache.load("a")
+        inner.load.assert_called_once_with("a")
+
+    def test_access_refreshes_lru_order(self) -> None:
+        inner = _make_inner()
+        inner.load = MagicMock(side_effect=lambda name: name.encode())
+        cache = CachedModelStore(inner, ttl_seconds=60.0, max_entries=3)
+
+        cache.load("a")
+        cache.load("b")
+        cache.load("c")
+
+        # Access 'a' to refresh its timestamp
+        cache.load("a")
+
+        # Now add 'd' - should evict 'b' (oldest after refresh)
+        cache.load("d")
+
+        inner.load.reset_mock()
+        # 'a' should still be cached (was refreshed)
+        cache.load("a")
+        inner.load.assert_not_called()
+
+        # 'b' should have been evicted
+        cache.load("b")
+        inner.load.assert_called_once_with("b")
+
+
+class TestCachedModelStoreThreadSafety:
+    """Thread safety under concurrent access."""
+
+    def test_concurrent_loads(self) -> None:
+        inner = _make_inner()
+        call_count = 0
+        lock = threading.Lock()
+
+        def counting_load(name: str) -> bytes:
+            nonlocal call_count
+            with lock:
+                call_count += 1
+            time.sleep(0.01)  # simulate I/O
+            return b"data"
+
+        inner.load = MagicMock(side_effect=counting_load)
+        cache = CachedModelStore(inner, ttl_seconds=60.0, max_entries=100)
+
+        errors: list[Exception] = []
+
+        def worker(model_name: str) -> None:
+            try:
+                for _ in range(10):
+                    cache.load(model_name)
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=worker, args=(f"model_{i % 5}",)) for i in range(20)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors, f"Thread errors: {errors}"
+
+    def test_concurrent_save_and_load(self) -> None:
+        inner = _make_inner()
+        cache = CachedModelStore(inner, ttl_seconds=60.0, max_entries=100)
+        errors: list[Exception] = []
+
+        def writer() -> None:
+            try:
+                for i in range(50):
+                    cache.save(f"m_{i % 5}", f"v{i}".encode())
+            except Exception as e:
+                errors.append(e)
+
+        def reader() -> None:
+            try:
+                for i in range(50):
+                    cache.load(f"m_{i % 5}")
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=writer) for _ in range(5)]
+        threads += [threading.Thread(target=reader) for _ in range(5)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors, f"Thread errors: {errors}"


### PR DESCRIPTION
## Summary

- Adds `--mode cloud` option to `sigil-ml serve` for stateless K8s deployment
- `ServingMode` enum (LOCAL/CLOUD) with CLI flag > env var > default resolution
- Cloud mode: no SQLite, no poller, no scheduler — stateless prediction API only
- Tenant identification via `X-Tenant-ID` header (configurable), 401 if missing
- Model cache with TTL and LRU eviction for cloud model loading
- `/predict/*` endpoints require features in body in cloud mode (400 on task_id-only)
- `/train` returns 405 in cloud mode
- `/health` reports serving mode and model cache status
- All local mode behavior preserved exactly (zero regression)

## Related Issues

Closes #15

Work packages: #19, #27, #34, #36, #37, #38

## Dependencies

Builds on Feature 002 + Feature 003 — PR based on `feature/003-model-storage-abstraction`

## Test plan

- [x] All 52 existing tests pass (zero regressions)
- [ ] Manual: `sigil-ml serve` works identically to before
- [ ] Manual: `sigil-ml serve --mode cloud` starts without SQLite
- [ ] Manual: Cloud mode returns 401 without X-Tenant-ID header

🤖 Generated with [Claude Code](https://claude.com/claude-code)