### PR TITLE
feat: fleet team-level ML models (focus, meeting, onboarding)

### DIFF
--- a/src/sigil_ml/app.py
+++ b/src/sigil_ml/app.py
@@ -20,6 +20,7 @@ from sigil_ml.models.quality import QualityEstimator
 from sigil_ml.models.stuck import StuckPredictor
 from sigil_ml.models.workflow import WorkflowStatePredictor
 from sigil_ml.poller import EventPoller
+from sigil_ml.models.fleet_routes import register_fleet_routes
 from sigil_ml.routes import register_routes
 from sigil_ml.storage.model_store import ModelStore, model_store_factory
 from sigil_ml.store import DataStore, create_store
@@ -219,6 +220,7 @@ def create_app(mode: ServingMode | None = None) -> FastAPI:
     )
 
     register_routes(application, state)
+    register_fleet_routes(application, state)
 
     return application
 

--- a/src/sigil_ml/models/fleet_focus.py
+++ b/src/sigil_ml/models/fleet_focus.py
@@ -1,0 +1,159 @@
+"""Fleet team focus model — predict focus score by hour/day for a team."""
+
+from __future__ import annotations
+
+import io
+import logging
+from typing import Any
+
+import joblib
+import numpy as np
+from sklearn.ensemble import GradientBoostingRegressor
+from sklearn.metrics import mean_squared_error, r2_score
+
+from sigil_ml.storage.model_store import LocalModelStore, ModelStore
+
+logger = logging.getLogger(__name__)
+
+FEATURE_NAMES = [
+    "hour",
+    "day_of_week",
+    "meeting_minutes",
+    "context_switches",
+]
+
+DAYS = ["mon", "tue", "wed", "thu", "fri", "sat", "sun"]
+
+
+class FleetFocusModel:
+    """Predicts focus score by hour and day-of-week for a team.
+
+    Used by the fleet aggregation layer to identify optimal work windows.
+    Model artifacts are stored per-team: ``fleet_focus_{team_id}``.
+    """
+
+    def __init__(self, team_id: int, model_store: ModelStore | None = None) -> None:
+        self._store = model_store or LocalModelStore()
+        self._team_id = team_id
+        self.model: GradientBoostingRegressor | None = None
+        self._trained = False
+        self._samples = 0
+
+        data = self._store.load(self._model_name)
+        if data is not None:
+            try:
+                loaded = joblib.load(io.BytesIO(data))
+                self.model = loaded["model"]
+                self._samples = loaded.get("samples", 0)
+                self._trained = True
+                logger.info("Loaded fleet focus model for team %d", team_id)
+            except Exception:
+                logger.warning("Failed to load fleet focus model for team %d", team_id)
+                self.model = None
+
+    @property
+    def _model_name(self) -> str:
+        return f"fleet_focus_{self._team_id}"
+
+    @property
+    def is_trained(self) -> bool:
+        return self._trained
+
+    def train(self, data: list[dict[str, Any]]) -> dict[str, Any]:
+        """Train on hourly team aggregate data.
+
+        Each row should have: hour, day_of_week, meeting_minutes,
+        context_switches, focus_score.
+
+        Returns:
+            Training result with metrics (rmse, r2).
+        """
+        if len(data) < 5:
+            raise ValueError("Need at least 5 data points for training")
+
+        features = []
+        targets = []
+        for row in data:
+            features.append([
+                row.get("hour", 12),
+                row.get("day_of_week", 0),
+                row.get("meeting_minutes", 0),
+                row.get("context_switches", 0),
+            ])
+            targets.append(row.get("focus_score", 50))
+
+        X = np.array(features)
+        y = np.array(targets)
+
+        self.model = GradientBoostingRegressor(
+            n_estimators=100,
+            max_depth=4,
+            random_state=42,
+        )
+        self.model.fit(X, y)
+        self._trained = True
+        self._samples = len(data)
+
+        predictions = self.model.predict(X)
+        rmse = float(np.sqrt(mean_squared_error(y, predictions)))
+        r2 = float(r2_score(y, predictions))
+
+        buf = io.BytesIO()
+        joblib.dump({"model": self.model, "samples": self._samples}, buf)
+        self._store.save(self._model_name, buf.getvalue())
+        logger.info("Saved fleet focus model for team %d (%d samples)", self._team_id, self._samples)
+
+        return {
+            "model": "fleet_focus",
+            "team_id": self._team_id,
+            "samples": self._samples,
+            "metrics": {"rmse": round(rmse, 3), "r2": round(r2, 3)},
+        }
+
+    def predict(self) -> dict[str, Any]:
+        """Predict focus score for each hour/day combination.
+
+        Returns:
+            Dict with per-day predictions (7x24 grid) and optimal windows.
+        """
+        if self.model is None or not self._trained:
+            return {"predictions": {}, "optimal_windows": []}
+
+        predictions: dict[str, list[float]] = {}
+        optimal_windows: list[dict[str, Any]] = []
+
+        for day_idx, day_name in enumerate(DAYS):
+            day_preds = []
+            for hour in range(24):
+                X = np.array([[hour, day_idx, 30, 10]])
+                score = float(self.model.predict(X)[0])
+                day_preds.append(round(max(0, min(100, score)), 1))
+            predictions[day_name] = day_preds
+
+            # Find optimal windows (contiguous blocks above 75th percentile)
+            threshold = float(np.percentile(day_preds, 75))
+            in_window = False
+            start = 0
+            for h, s in enumerate(day_preds):
+                if s >= threshold and not in_window:
+                    in_window = True
+                    start = h
+                elif (s < threshold or h == 23) and in_window:
+                    end = h if s < threshold else h + 1
+                    if end - start >= 2:
+                        avg_score = float(np.mean(day_preds[start:end]))
+                        optimal_windows.append({
+                            "day": day_name,
+                            "start": start,
+                            "end": end,
+                            "predicted_score": round(avg_score, 1),
+                        })
+                    in_window = False
+
+        optimal_windows.sort(key=lambda x: x["predicted_score"], reverse=True)
+
+        return {
+            "predictions": predictions,
+            "optimal_windows": optimal_windows[:5],
+            "samples": self._samples,
+        }

--- a/src/sigil_ml/models/fleet_focus.py
+++ b/src/sigil_ml/models/fleet_focus.py
@@ -15,13 +15,6 @@ from sigil_ml.storage.model_store import LocalModelStore, ModelStore
 
 logger = logging.getLogger(__name__)
 
-FEATURE_NAMES = [
-    "hour",
-    "day_of_week",
-    "meeting_minutes",
-    "context_switches",
-]
-
 DAYS = ["mon", "tue", "wed", "thu", "fri", "sat", "sun"]
 
 

--- a/src/sigil_ml/models/fleet_meeting.py
+++ b/src/sigil_ml/models/fleet_meeting.py
@@ -1,0 +1,125 @@
+"""Fleet meeting impact model — quantify meeting disruption for a team."""
+
+from __future__ import annotations
+
+import io
+import logging
+from typing import Any
+
+import joblib
+import numpy as np
+from sklearn.ensemble import RandomForestClassifier
+
+from sigil_ml.storage.model_store import LocalModelStore, ModelStore
+
+logger = logging.getLogger(__name__)
+
+DISRUPTION_LABELS = {0: "low", 1: "medium", 2: "high"}
+
+
+class FleetMeetingModel:
+    """Classifies meeting disruption level and estimates recovery time.
+
+    Used by the fleet aggregation layer to quantify how meetings affect
+    team productivity. Model artifacts stored per-team: ``fleet_meeting_{team_id}``.
+    """
+
+    def __init__(self, team_id: int, model_store: ModelStore | None = None) -> None:
+        self._store = model_store or LocalModelStore()
+        self._team_id = team_id
+        self.model: RandomForestClassifier | None = None
+        self._trained = False
+        self._samples = 0
+
+        data = self._store.load(self._model_name)
+        if data is not None:
+            try:
+                loaded = joblib.load(io.BytesIO(data))
+                self.model = loaded["model"]
+                self._samples = loaded.get("samples", 0)
+                self._trained = True
+                logger.info("Loaded fleet meeting model for team %d", team_id)
+            except Exception:
+                logger.warning("Failed to load fleet meeting model for team %d", team_id)
+                self.model = None
+
+    @property
+    def _model_name(self) -> str:
+        return f"fleet_meeting_{self._team_id}"
+
+    @property
+    def is_trained(self) -> bool:
+        return self._trained
+
+    def train(self, data: list[dict[str, Any]]) -> dict[str, Any]:
+        """Train on meeting impact data.
+
+        Each row should have: meeting_duration, time_of_day, focus_before,
+        focus_after.
+
+        Returns:
+            Training result with accuracy metric.
+        """
+        if len(data) < 5:
+            raise ValueError("Need at least 5 data points for training")
+
+        features = []
+        targets = []
+        for row in data:
+            duration = row.get("meeting_duration", 30)
+            time_of_day = row.get("time_of_day", 10)
+            focus_before = row.get("focus_before", 70)
+            focus_after = row.get("focus_after", 50)
+            features.append([duration, time_of_day, focus_before])
+            delta = focus_before - focus_after
+            if delta > 20:
+                targets.append(2)  # high disruption
+            elif delta > 10:
+                targets.append(1)  # medium
+            else:
+                targets.append(0)  # low
+
+        X = np.array(features)
+        y = np.array(targets)
+
+        self.model = RandomForestClassifier(n_estimators=50, random_state=42)
+        self.model.fit(X, y)
+        self._trained = True
+        self._samples = len(data)
+
+        accuracy = float(self.model.score(X, y))
+
+        buf = io.BytesIO()
+        joblib.dump({"model": self.model, "samples": self._samples}, buf)
+        self._store.save(self._model_name, buf.getvalue())
+        logger.info("Saved fleet meeting model for team %d (%d samples)", self._team_id, self._samples)
+
+        return {
+            "model": "fleet_meeting",
+            "team_id": self._team_id,
+            "samples": self._samples,
+            "metrics": {"accuracy": round(accuracy, 3)},
+        }
+
+    def predict(self) -> dict[str, Any]:
+        """Predict disruption level for common meeting scenarios.
+
+        Returns:
+            Dict with disruption scenarios (duration x time_of_day grid).
+        """
+        if self.model is None or not self._trained:
+            return {"scenarios": []}
+
+        scenarios = []
+        for duration in [15, 30, 45, 60, 90]:
+            for tod in [9, 11, 14, 16]:
+                X = np.array([[duration, tod, 70]])
+                pred = int(self.model.predict(X)[0])
+                scenarios.append({
+                    "duration": duration,
+                    "time_of_day": tod,
+                    "disruption": DISRUPTION_LABELS.get(pred, "unknown"),
+                    "recovery_estimate_min": pred * 30,
+                })
+
+        return {"scenarios": scenarios, "samples": self._samples}

--- a/src/sigil_ml/models/fleet_onboarding.py
+++ b/src/sigil_ml/models/fleet_onboarding.py
@@ -1,0 +1,115 @@
+"""Fleet onboarding model — predict ramp-up trajectory for new team members."""
+
+from __future__ import annotations
+
+import io
+import logging
+from typing import Any
+
+import joblib
+import numpy as np
+from sklearn.linear_model import LinearRegression
+
+from sigil_ml.storage.model_store import LocalModelStore, ModelStore
+
+logger = logging.getLogger(__name__)
+
+
+class FleetOnboardingModel:
+    """Predicts ramp-up trajectory for new team members.
+
+    Estimates how many days until a new member reaches 80% of team
+    baseline productivity. Model artifacts stored per-team:
+    ``fleet_onboarding_{team_id}``.
+    """
+
+    def __init__(self, team_id: int, model_store: ModelStore | None = None) -> None:
+        self._store = model_store or LocalModelStore()
+        self._team_id = team_id
+        self.model: LinearRegression | None = None
+        self._trained = False
+        self._samples = 0
+
+        data = self._store.load(self._model_name)
+        if data is not None:
+            try:
+                loaded = joblib.load(io.BytesIO(data))
+                self.model = loaded["model"]
+                self._samples = loaded.get("samples", 0)
+                self._trained = True
+                logger.info("Loaded fleet onboarding model for team %d", team_id)
+            except Exception:
+                logger.warning("Failed to load fleet onboarding model for team %d", team_id)
+                self.model = None
+
+    @property
+    def _model_name(self) -> str:
+        return f"fleet_onboarding_{self._team_id}"
+
+    @property
+    def is_trained(self) -> bool:
+        return self._trained
+
+    def train(self, data: list[dict[str, Any]]) -> dict[str, Any]:
+        """Train on new-member ramp-up data.
+
+        Each row should have: day_number, performance_pct (relative to
+        team baseline).
+
+        Returns:
+            Training result with r2 metric.
+        """
+        if len(data) < 5:
+            raise ValueError("Need at least 5 data points for training")
+
+        features = []
+        targets = []
+        for row in data:
+            features.append([row.get("day_number", 1)])
+            targets.append(row.get("performance_pct", 50))
+
+        X = np.array(features)
+        y = np.array(targets)
+
+        self.model = LinearRegression()
+        self.model.fit(X, y)
+        self._trained = True
+        self._samples = len(data)
+
+        r2 = float(self.model.score(X, y))
+
+        buf = io.BytesIO()
+        joblib.dump({"model": self.model, "samples": self._samples}, buf)
+        self._store.save(self._model_name, buf.getvalue())
+        logger.info("Saved fleet onboarding model for team %d (%d samples)", self._team_id, self._samples)
+
+        return {
+            "model": "fleet_onboarding",
+            "team_id": self._team_id,
+            "samples": self._samples,
+            "metrics": {"r2": round(r2, 3)},
+        }
+
+    def predict(self) -> dict[str, Any]:
+        """Predict ramp-up trajectory over 90 days.
+
+        Returns:
+            Dict with day-by-day trajectory and predicted ramp-up day.
+        """
+        if self.model is None or not self._trained:
+            return {"trajectory": [], "predicted_ramp_up_days": None}
+
+        trajectory = []
+        ramp_up_day = None
+        for day in range(1, 91):
+            pct = float(self.model.predict(np.array([[day]]))[0])
+            pct = max(0.0, min(100.0, pct))
+            trajectory.append({"day": day, "predicted_pct": round(pct, 1)})
+            if ramp_up_day is None and pct >= 80:
+                ramp_up_day = day
+
+        return {
+            "trajectory": trajectory,
+            "predicted_ramp_up_days": ramp_up_day,
+            "samples": self._samples,
+        }

--- a/src/sigil_ml/models/fleet_routes.py
+++ b/src/sigil_ml/models/fleet_routes.py
@@ -51,15 +51,25 @@ MODEL_NAMES = {"focus", "meeting", "onboarding"}
 def register_fleet_routes(fastapi_app: FastAPI, state: AppState) -> None:
     """Register fleet model training and prediction routes."""
 
-    def _get_model(model_name: str, team_id: int):
+    # Cache model instances to avoid reloading from disk on every request.
+    _cache: dict[str, FleetFocusModel | FleetMeetingModel | FleetOnboardingModel] = {}
+
+    def _get_model(model_name: str, team_id: int, *, force_reload: bool = False):
+        key = f"{model_name}_{team_id}"
+        if not force_reload and key in _cache:
+            return _cache[key]
+
         store = state.model_store
         if model_name == "focus":
-            return FleetFocusModel(team_id, model_store=store)
+            m = FleetFocusModel(team_id, model_store=store)
         elif model_name == "meeting":
-            return FleetMeetingModel(team_id, model_store=store)
+            m = FleetMeetingModel(team_id, model_store=store)
         elif model_name == "onboarding":
-            return FleetOnboardingModel(team_id, model_store=store)
-        raise HTTPException(status_code=404, detail=f"Unknown fleet model: {model_name}")
+            m = FleetOnboardingModel(team_id, model_store=store)
+        else:
+            raise HTTPException(status_code=404, detail=f"Unknown fleet model: {model_name}")
+        _cache[key] = m
+        return m
 
     @fastapi_app.post("/fleet/train/{model_name}", response_model=FleetTrainResponse)
     async def fleet_train(model_name: str, req: FleetTrainRequest) -> FleetTrainResponse:
@@ -67,7 +77,7 @@ def register_fleet_routes(fastapi_app: FastAPI, state: AppState) -> None:
         if model_name not in MODEL_NAMES:
             raise HTTPException(status_code=404, detail=f"Unknown fleet model: {model_name}")
 
-        model = _get_model(model_name, req.team_id)
+        model = _get_model(model_name, req.team_id, force_reload=True)
         try:
             result = model.train(req.data)
         except ValueError as e:
@@ -98,11 +108,13 @@ def register_fleet_routes(fastapi_app: FastAPI, state: AppState) -> None:
             )
 
         preds = model.predict()
-        samples = preds.pop("samples", 0)
+        samples = preds.get("samples", 0)
+        # Build predictions dict without the samples key.
+        predictions = {k: v for k, v in preds.items() if k != "samples"}
         return FleetPredictResponse(
             model=f"fleet_{model_name}",
             team_id=team_id,
-            predictions=preds,
+            predictions=predictions,
             samples=samples,
         )
 

--- a/src/sigil_ml/models/fleet_routes.py
+++ b/src/sigil_ml/models/fleet_routes.py
@@ -1,0 +1,116 @@
+"""Fleet model API routes — training and prediction endpoints for team-level models."""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel, Field
+
+from sigil_ml.models.fleet_focus import FleetFocusModel
+from sigil_ml.models.fleet_meeting import FleetMeetingModel
+from sigil_ml.models.fleet_onboarding import FleetOnboardingModel
+
+if TYPE_CHECKING:
+    from sigil_ml.app import AppState
+
+logger = logging.getLogger(__name__)
+
+
+# ---------- Request / Response schemas ----------
+
+
+class FleetTrainRequest(BaseModel):
+    team_id: int
+    data: list[dict[str, Any]] = Field(..., min_length=5)
+
+
+class FleetTrainResponse(BaseModel):
+    model: str
+    team_id: int
+    samples: int
+    trained_at: str
+    metrics: dict[str, float]
+
+
+class FleetPredictResponse(BaseModel):
+    model: str
+    team_id: int
+    predictions: dict[str, Any]
+    trained_at: str | None = None
+    samples: int = 0
+
+
+# ---------- Route registration ----------
+
+MODEL_NAMES = {"focus", "meeting", "onboarding"}
+
+
+def register_fleet_routes(fastapi_app: FastAPI, state: AppState) -> None:
+    """Register fleet model training and prediction routes."""
+
+    def _get_model(model_name: str, team_id: int):
+        store = state.model_store
+        if model_name == "focus":
+            return FleetFocusModel(team_id, model_store=store)
+        elif model_name == "meeting":
+            return FleetMeetingModel(team_id, model_store=store)
+        elif model_name == "onboarding":
+            return FleetOnboardingModel(team_id, model_store=store)
+        raise HTTPException(status_code=404, detail=f"Unknown fleet model: {model_name}")
+
+    @fastapi_app.post("/fleet/train/{model_name}", response_model=FleetTrainResponse)
+    async def fleet_train(model_name: str, req: FleetTrainRequest) -> FleetTrainResponse:
+        """Train a fleet model for a specific team."""
+        if model_name not in MODEL_NAMES:
+            raise HTTPException(status_code=404, detail=f"Unknown fleet model: {model_name}")
+
+        model = _get_model(model_name, req.team_id)
+        try:
+            result = model.train(req.data)
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=str(e)) from e
+
+        return FleetTrainResponse(
+            model=result["model"],
+            team_id=result["team_id"],
+            samples=result["samples"],
+            trained_at=datetime.now(timezone.utc).isoformat(),
+            metrics=result["metrics"],
+        )
+
+    @fastapi_app.get("/fleet/predict/{model_name}", response_model=FleetPredictResponse)
+    async def fleet_predict(model_name: str, team_id: int) -> FleetPredictResponse:
+        """Get predictions from a trained fleet model."""
+        if model_name not in MODEL_NAMES:
+            raise HTTPException(status_code=404, detail=f"Unknown fleet model: {model_name}")
+
+        model = _get_model(model_name, team_id)
+        if not model.is_trained:
+            return FleetPredictResponse(
+                model=f"fleet_{model_name}",
+                team_id=team_id,
+                predictions={},
+                trained_at=None,
+                samples=0,
+            )
+
+        preds = model.predict()
+        samples = preds.pop("samples", 0)
+        return FleetPredictResponse(
+            model=f"fleet_{model_name}",
+            team_id=team_id,
+            predictions=preds,
+            samples=samples,
+        )
+
+    @fastapi_app.get("/fleet/health")
+    async def fleet_health() -> dict[str, Any]:
+        """Fleet model subsystem health check."""
+        return {
+            "status": "ok",
+            "models": list(MODEL_NAMES),
+            "store": type(state.model_store).__name__ if state.model_store else "none",
+        }

--- a/tests/test_fleet_models.py
+++ b/tests/test_fleet_models.py
@@ -1,0 +1,154 @@
+"""Tests for fleet team-level models (focus, meeting, onboarding)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from sigil_ml.models.fleet_focus import FleetFocusModel
+from sigil_ml.models.fleet_meeting import FleetMeetingModel
+from sigil_ml.models.fleet_onboarding import FleetOnboardingModel
+from sigil_ml.storage.model_store import LocalModelStore
+
+
+@pytest.fixture
+def tmp_store(tmp_path: Path) -> LocalModelStore:
+    """Create a temporary LocalModelStore."""
+    return LocalModelStore(base_dir=tmp_path)
+
+
+# ---------- FleetFocusModel ----------
+
+
+class TestFleetFocusModel:
+    def test_untrained_predict_returns_empty(self, tmp_store: LocalModelStore) -> None:
+        model = FleetFocusModel(team_id=1, model_store=tmp_store)
+        assert not model.is_trained
+        result = model.predict()
+        assert result["predictions"] == {}
+        assert result["optimal_windows"] == []
+
+    def test_train_and_predict(self, tmp_store: LocalModelStore) -> None:
+        model = FleetFocusModel(team_id=1, model_store=tmp_store)
+        data = [
+            {"hour": h, "day_of_week": d, "meeting_minutes": 20, "context_switches": 5, "focus_score": 60 + h}
+            for h in range(8, 18)
+            for d in range(5)
+        ]
+        result = model.train(data)
+        assert result["model"] == "fleet_focus"
+        assert result["team_id"] == 1
+        assert result["samples"] == 50
+        assert "rmse" in result["metrics"]
+        assert "r2" in result["metrics"]
+        assert model.is_trained
+
+        preds = model.predict()
+        assert "mon" in preds["predictions"]
+        assert len(preds["predictions"]["mon"]) == 24
+
+    def test_train_too_few_samples(self, tmp_store: LocalModelStore) -> None:
+        model = FleetFocusModel(team_id=1, model_store=tmp_store)
+        with pytest.raises(ValueError, match="at least 5"):
+            model.train([{"hour": 1, "focus_score": 50}])
+
+    def test_persistence_roundtrip(self, tmp_store: LocalModelStore) -> None:
+        model = FleetFocusModel(team_id=42, model_store=tmp_store)
+        data = [
+            {"hour": h, "day_of_week": 0, "meeting_minutes": 10, "context_switches": 3, "focus_score": 50 + h}
+            for h in range(10)
+        ]
+        model.train(data)
+
+        # Load a fresh instance — should pick up the saved model
+        loaded = FleetFocusModel(team_id=42, model_store=tmp_store)
+        assert loaded.is_trained
+        preds = loaded.predict()
+        assert len(preds["predictions"]) == 7
+
+
+# ---------- FleetMeetingModel ----------
+
+
+class TestFleetMeetingModel:
+    def test_untrained_predict_returns_empty(self, tmp_store: LocalModelStore) -> None:
+        model = FleetMeetingModel(team_id=1, model_store=tmp_store)
+        assert not model.is_trained
+        result = model.predict()
+        assert result["scenarios"] == []
+
+    def test_train_and_predict(self, tmp_store: LocalModelStore) -> None:
+        model = FleetMeetingModel(team_id=1, model_store=tmp_store)
+        data = [
+            {"meeting_duration": d, "time_of_day": 10, "focus_before": 80, "focus_after": 80 - d // 2}
+            for d in range(10, 100, 5)
+        ]
+        result = model.train(data)
+        assert result["model"] == "fleet_meeting"
+        assert result["samples"] == len(data)
+        assert "accuracy" in result["metrics"]
+
+        preds = model.predict()
+        assert len(preds["scenarios"]) > 0
+        for s in preds["scenarios"]:
+            assert s["disruption"] in ("low", "medium", "high")
+
+    def test_train_too_few_samples(self, tmp_store: LocalModelStore) -> None:
+        model = FleetMeetingModel(team_id=1, model_store=tmp_store)
+        with pytest.raises(ValueError, match="at least 5"):
+            model.train([{"meeting_duration": 30}])
+
+    def test_persistence_roundtrip(self, tmp_store: LocalModelStore) -> None:
+        model = FleetMeetingModel(team_id=7, model_store=tmp_store)
+        data = [
+            {"meeting_duration": d, "time_of_day": 10, "focus_before": 80, "focus_after": 60}
+            for d in range(10, 60, 5)
+        ]
+        model.train(data)
+
+        loaded = FleetMeetingModel(team_id=7, model_store=tmp_store)
+        assert loaded.is_trained
+
+
+# ---------- FleetOnboardingModel ----------
+
+
+class TestFleetOnboardingModel:
+    def test_untrained_predict_returns_empty(self, tmp_store: LocalModelStore) -> None:
+        model = FleetOnboardingModel(team_id=1, model_store=tmp_store)
+        assert not model.is_trained
+        result = model.predict()
+        assert result["trajectory"] == []
+        assert result["predicted_ramp_up_days"] is None
+
+    def test_train_and_predict(self, tmp_store: LocalModelStore) -> None:
+        model = FleetOnboardingModel(team_id=1, model_store=tmp_store)
+        # Linear ramp: day 1 → 20%, day 90 → 100%
+        data = [{"day_number": d, "performance_pct": 20 + (80 * d / 90)} for d in range(1, 91)]
+        result = model.train(data)
+        assert result["model"] == "fleet_onboarding"
+        assert result["samples"] == 90
+        assert "r2" in result["metrics"]
+        assert result["metrics"]["r2"] > 0.9  # linear data should fit well
+
+        preds = model.predict()
+        assert len(preds["trajectory"]) == 90
+        # Ramp-up should be predicted around day 67-68 (when 20 + 80*d/90 >= 80)
+        assert preds["predicted_ramp_up_days"] is not None
+        assert 60 <= preds["predicted_ramp_up_days"] <= 75
+
+    def test_train_too_few_samples(self, tmp_store: LocalModelStore) -> None:
+        model = FleetOnboardingModel(team_id=1, model_store=tmp_store)
+        with pytest.raises(ValueError, match="at least 5"):
+            model.train([{"day_number": 1, "performance_pct": 20}])
+
+    def test_persistence_roundtrip(self, tmp_store: LocalModelStore) -> None:
+        model = FleetOnboardingModel(team_id=99, model_store=tmp_store)
+        data = [{"day_number": d, "performance_pct": d} for d in range(1, 20)]
+        model.train(data)
+
+        loaded = FleetOnboardingModel(team_id=99, model_store=tmp_store)
+        assert loaded.is_trained
+        preds = loaded.predict()
+        assert len(preds["trajectory"]) == 90


### PR DESCRIPTION
## Summary

- Add three team-level ML models for the fleet aggregation layer:
  - **FleetFocusModel** — GradientBoostingRegressor predicting focus score by hour/day with optimal work window detection
  - **FleetMeetingModel** — RandomForestClassifier classifying meeting disruption (low/medium/high) with recovery time estimates
  - **FleetOnboardingModel** — LinearRegression predicting new-member ramp-up trajectory over 90 days
- Register fleet routes at `/fleet/train/{model}`, `/fleet/predict/{model}`, `/fleet/health`
- All models follow existing patterns: `ModelStore` protocol, joblib serialization, per-team artifacts (`fleet_focus_{team_id}`)
- 12 tests covering train, predict, persistence roundtrip, and input validation

## Test plan

- [x] `pytest tests/test_fleet_models.py` — 12/12 passing
- [ ] Verify fleet service can call `/fleet/predict/focus?team_id=1` via `FLEET_ML_URL`
- [ ] Verify model persistence survives sidecar restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)