### PR TITLE
feat: auto-generated OpenAPI spec with CI freshness check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,6 +139,23 @@ jobs:
         run: |
           sigil-ml health-check 2>&1 && exit 1 || echo "Expected failure — server not running"
 
+  openapi:
+    name: OpenAPI Spec
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: pip install -e ".[dev]"
+
+      - name: Verify OpenAPI spec is up to date
+        run: make openapi-check
+
   build:
     runs-on: ubuntu-latest
     steps:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,27 @@
+.PHONY: openapi openapi-check install lint format test build clean
+
+# Generate the OpenAPI spec from the FastAPI app
+openapi:
+	python scripts/gen_openapi.py
+
+# Verify the committed spec matches the code (used by CI)
+openapi-check:
+	python scripts/gen_openapi.py --check
+
+install:
+	pip install -e ".[dev]"
+
+lint:
+	ruff check src/ tests/
+
+format:
+	ruff format src/ tests/
+
+test:
+	pytest tests/ -v
+
+build:
+	python -m build
+
+clean:
+	rm -rf dist/ build/ *.egg-info src/*.egg-info

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1,0 +1,855 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "sigil-ml",
+    "description": "Sigil ML sidecar (local mode)",
+    "version": "0.1.0"
+  },
+  "paths": {
+    "/health": {
+      "get": {
+        "summary": "Health",
+        "operationId": "health_health_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HealthResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/status": {
+      "get": {
+        "summary": "Status",
+        "operationId": "status_status_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "type": "object",
+                  "title": "Response Status Status Get"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/predict/stuck": {
+      "post": {
+        "summary": "Predict Stuck",
+        "operationId": "predict_stuck_predict_stuck_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/StuckRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StuckResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/predict/suggest": {
+      "post": {
+        "summary": "Predict Suggest",
+        "operationId": "predict_suggest_predict_suggest_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WorkflowStateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowStateResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/predict/duration": {
+      "post": {
+        "summary": "Predict Duration",
+        "operationId": "predict_duration_predict_duration_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DurationRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DurationResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/predict/quality": {
+      "post": {
+        "summary": "Predict Quality",
+        "operationId": "predict_quality_predict_quality_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/QualityRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QualityResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/plugins": {
+      "get": {
+        "summary": "Plugins",
+        "operationId": "plugins_plugins_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "type": "object",
+                  "title": "Response Plugins Plugins Get"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/train": {
+      "post": {
+        "summary": "Train",
+        "operationId": "train_train_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TrainRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TrainResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/": {
+      "get": {
+        "summary": "Root",
+        "operationId": "root__get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "type": "object",
+                  "title": "Response Root  Get"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/fleet/train/{model_name}": {
+      "post": {
+        "summary": "Fleet Train",
+        "description": "Train a fleet model for a specific team.",
+        "operationId": "fleet_train_fleet_train__model_name__post",
+        "parameters": [
+          {
+            "name": "model_name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Model Name"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FleetTrainRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FleetTrainResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/fleet/predict/{model_name}": {
+      "get": {
+        "summary": "Fleet Predict",
+        "description": "Get predictions from a trained fleet model.",
+        "operationId": "fleet_predict_fleet_predict__model_name__get",
+        "parameters": [
+          {
+            "name": "model_name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Model Name"
+            }
+          },
+          {
+            "name": "team_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Team Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FleetPredictResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/fleet/health": {
+      "get": {
+        "summary": "Fleet Health",
+        "description": "Fleet model subsystem health check.",
+        "operationId": "fleet_health_fleet_health_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "type": "object",
+                  "title": "Response Fleet Health Fleet Health Get"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "DurationRequest": {
+        "properties": {
+          "task_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Task Id"
+          },
+          "features": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "type": "number"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Features"
+          }
+        },
+        "type": "object",
+        "title": "DurationRequest"
+      },
+      "DurationResponse": {
+        "properties": {
+          "estimated_minutes": {
+            "type": "number",
+            "title": "Estimated Minutes"
+          },
+          "confidence_interval": {
+            "items": {
+              "type": "number"
+            },
+            "type": "array",
+            "title": "Confidence Interval"
+          }
+        },
+        "type": "object",
+        "required": [
+          "estimated_minutes",
+          "confidence_interval"
+        ],
+        "title": "DurationResponse"
+      },
+      "FleetPredictResponse": {
+        "properties": {
+          "model": {
+            "type": "string",
+            "title": "Model"
+          },
+          "team_id": {
+            "type": "integer",
+            "title": "Team Id"
+          },
+          "predictions": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Predictions"
+          },
+          "trained_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Trained At"
+          },
+          "samples": {
+            "type": "integer",
+            "title": "Samples",
+            "default": 0
+          }
+        },
+        "type": "object",
+        "required": [
+          "model",
+          "team_id",
+          "predictions"
+        ],
+        "title": "FleetPredictResponse"
+      },
+      "FleetTrainRequest": {
+        "properties": {
+          "team_id": {
+            "type": "integer",
+            "title": "Team Id"
+          },
+          "data": {
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "type": "array",
+            "minItems": 5,
+            "title": "Data"
+          }
+        },
+        "type": "object",
+        "required": [
+          "team_id",
+          "data"
+        ],
+        "title": "FleetTrainRequest"
+      },
+      "FleetTrainResponse": {
+        "properties": {
+          "model": {
+            "type": "string",
+            "title": "Model"
+          },
+          "team_id": {
+            "type": "integer",
+            "title": "Team Id"
+          },
+          "samples": {
+            "type": "integer",
+            "title": "Samples"
+          },
+          "trained_at": {
+            "type": "string",
+            "title": "Trained At"
+          },
+          "metrics": {
+            "additionalProperties": {
+              "type": "number"
+            },
+            "type": "object",
+            "title": "Metrics"
+          }
+        },
+        "type": "object",
+        "required": [
+          "model",
+          "team_id",
+          "samples",
+          "trained_at",
+          "metrics"
+        ],
+        "title": "FleetTrainResponse"
+      },
+      "HTTPValidationError": {
+        "properties": {
+          "detail": {
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            },
+            "type": "array",
+            "title": "Detail"
+          }
+        },
+        "type": "object",
+        "title": "HTTPValidationError"
+      },
+      "HealthResponse": {
+        "properties": {
+          "status": {
+            "type": "string",
+            "title": "Status"
+          },
+          "mode": {
+            "type": "string",
+            "title": "Mode",
+            "default": "local"
+          },
+          "models": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object",
+            "title": "Models"
+          },
+          "uptime_sec": {
+            "type": "number",
+            "title": "Uptime Sec"
+          }
+        },
+        "type": "object",
+        "required": [
+          "status",
+          "models",
+          "uptime_sec"
+        ],
+        "title": "HealthResponse"
+      },
+      "QualityRequest": {
+        "properties": {
+          "features": {
+            "additionalProperties": {
+              "type": "number"
+            },
+            "type": "object",
+            "title": "Features"
+          }
+        },
+        "type": "object",
+        "required": [
+          "features"
+        ],
+        "title": "QualityRequest"
+      },
+      "QualityResponse": {
+        "properties": {
+          "score": {
+            "type": "integer",
+            "title": "Score"
+          },
+          "components": {
+            "additionalProperties": {
+              "type": "number"
+            },
+            "type": "object",
+            "title": "Components"
+          },
+          "status": {
+            "type": "string",
+            "title": "Status"
+          }
+        },
+        "type": "object",
+        "required": [
+          "score",
+          "components",
+          "status"
+        ],
+        "title": "QualityResponse"
+      },
+      "StuckRequest": {
+        "properties": {
+          "task_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Task Id"
+          },
+          "features": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "type": "number"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Features"
+          }
+        },
+        "type": "object",
+        "title": "StuckRequest"
+      },
+      "StuckResponse": {
+        "properties": {
+          "probability": {
+            "type": "number",
+            "title": "Probability"
+          },
+          "confidence": {
+            "type": "string",
+            "title": "Confidence"
+          }
+        },
+        "type": "object",
+        "required": [
+          "probability",
+          "confidence"
+        ],
+        "title": "StuckResponse"
+      },
+      "TrainRequest": {
+        "properties": {
+          "db": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Db",
+            "description": "Deprecated: ignored, kept for backward compat"
+          }
+        },
+        "type": "object",
+        "title": "TrainRequest"
+      },
+      "TrainResponse": {
+        "properties": {
+          "status": {
+            "type": "string",
+            "title": "Status"
+          },
+          "message": {
+            "type": "string",
+            "title": "Message"
+          }
+        },
+        "type": "object",
+        "required": [
+          "status",
+          "message"
+        ],
+        "title": "TrainResponse"
+      },
+      "ValidationError": {
+        "properties": {
+          "loc": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "type": "array",
+            "title": "Location"
+          },
+          "msg": {
+            "type": "string",
+            "title": "Message"
+          },
+          "type": {
+            "type": "string",
+            "title": "Error Type"
+          },
+          "input": {
+            "title": "Input"
+          },
+          "ctx": {
+            "type": "object",
+            "title": "Context"
+          }
+        },
+        "type": "object",
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "title": "ValidationError"
+      },
+      "WorkflowStateRequest": {
+        "properties": {
+          "task_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Task Id"
+          },
+          "classified_events": {
+            "anyOf": [
+              {
+                "items": {
+                  "additionalProperties": true,
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Classified Events"
+          }
+        },
+        "type": "object",
+        "title": "WorkflowStateRequest"
+      },
+      "WorkflowStateResponse": {
+        "properties": {
+          "flow_state": {
+            "additionalProperties": {
+              "type": "number"
+            },
+            "type": "object",
+            "title": "Flow State"
+          },
+          "dominant_state": {
+            "type": "string",
+            "title": "Dominant State"
+          },
+          "momentum": {
+            "type": "number",
+            "title": "Momentum"
+          },
+          "focus_score": {
+            "type": "number",
+            "title": "Focus Score"
+          },
+          "dominant_activity": {
+            "type": "string",
+            "title": "Dominant Activity"
+          },
+          "activity_distribution": {
+            "additionalProperties": {
+              "type": "number"
+            },
+            "type": "object",
+            "title": "Activity Distribution"
+          },
+          "session_elapsed_min": {
+            "type": "number",
+            "title": "Session Elapsed Min"
+          },
+          "method": {
+            "type": "string",
+            "title": "Method"
+          },
+          "confidence": {
+            "type": "number",
+            "title": "Confidence"
+          }
+        },
+        "type": "object",
+        "required": [
+          "flow_state",
+          "dominant_state",
+          "momentum",
+          "focus_score",
+          "dominant_activity",
+          "activity_distribution",
+          "session_elapsed_min",
+          "method",
+          "confidence"
+        ],
+        "title": "WorkflowStateResponse"
+      }
+    }
+  }
+}

--- a/scripts/gen_openapi.py
+++ b/scripts/gen_openapi.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Generate the OpenAPI spec from the FastAPI app and write it to docs/openapi.yaml.
+
+Usage:
+    python scripts/gen_openapi.py          # write to docs/openapi.yaml
+    python scripts/gen_openapi.py --check  # exit 1 if spec is out of date
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+# Import the app to get the auto-generated schema.
+from sigil_ml.app import create_app
+from sigil_ml.config import ServingMode
+
+ROOT = Path(__file__).resolve().parent.parent
+SPEC_PATH = ROOT / "docs" / "openapi.json"
+
+
+def generate() -> str:
+    app = create_app(mode=ServingMode.LOCAL)
+    schema = app.openapi()
+    return json.dumps(schema, indent=2, sort_keys=False) + "\n"
+
+
+def main() -> None:
+    spec = generate()
+
+    if "--check" in sys.argv:
+        if not SPEC_PATH.exists():
+            print(f"FAIL: {SPEC_PATH} does not exist. Run 'make openapi' to generate it.")
+            sys.exit(1)
+        existing = SPEC_PATH.read_text()
+        if existing != spec:
+            print(f"FAIL: {SPEC_PATH} is out of date. Run 'make openapi' to update it.")
+            sys.exit(1)
+        print(f"OK: {SPEC_PATH} is up to date.")
+        return
+
+    SPEC_PATH.parent.mkdir(parents=True, exist_ok=True)
+    SPEC_PATH.write_text(spec)
+    print(f"Wrote {SPEC_PATH} ({len(spec)} bytes)")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Add `scripts/gen_openapi.py` that dumps FastAPI's auto-generated OpenAPI schema to `docs/openapi.json`
- Add `Makefile` with `make openapi` (regenerate) and `make openapi-check` (CI validation)
- Add `openapi` CI job that fails PRs when the committed spec doesn't match the code
- Commit the initial generated spec (all endpoints including fleet models)

## Workflow

Change a route or schema → `make openapi` → commit the updated spec alongside the code. CI catches forgotten updates.

## Test plan

- [x] `make openapi` generates `docs/openapi.json`
- [x] `make openapi-check` passes when spec is current
- [x] `make openapi-check` fails when spec is stale
- [x] 184/184 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)